### PR TITLE
Use PiCamera to combine camera overlays

### DIFF
--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -83,7 +83,7 @@ class Canvas():
 		dest = cv2.bitwise_and(dest, dest, mask=cv2.bitwise_not(mask))
 		return cv2.add(dest, img)
 
-	def update_pi_overlay(self, pi_camera: PiCamera, layer: int):
+	def update_pi_overlay(self, pi_camera, layer):
 		""" Adds the overlay to a PiCamera preview, and if the overlay was already added,
 		    removes the old instance. """
 		overlay = pi_camera.add_overlay(self.img, format="rgba", size=(self.width, self.height))
@@ -171,7 +171,7 @@ class Overlay(ABC):
 		frame = self.data_canvas.copy_to(frame)
 		frame = self.message_canvas.copy_to(frame)
 
-		cv2.imshow('frame', self.get_display())
+		cv2.imshow('frame', frame)
 		cv2.waitKey(self.frametime)
 
 	def connect(self, ip="192.168.100.100", port=1883):

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -92,7 +92,7 @@ class Canvas():
 		overlay.window = (0, -20, self.width, self.height)
 
 		# Rather than creating and swapping out overlays, the proper way to do this would be with overlay.update()
-		# Unfortunetly, due to a bug in PiCamera 1.13, this will spam us with errors (which don't matter, but still)
+		# Unfortunately, due to a bug in PiCamera 1.13, this will spam us with errors (which don't matter, but still)
 		# https://github.com/waveform80/picamera/issues/320
 		# https://www.raspberrypi.org/forums/viewtopic.php?t=190120
 		if self.overlay:
@@ -163,7 +163,7 @@ class Overlay(ABC):
 		}
 
 	def show_opencv_frame(self):
-		""" Creates the frame using the webcame and canvases, and displays result """
+		""" Creates the frame using the webcam and canvases, and displays result """
 		_, frame = self.webcam.read()
 		frame = cv2.resize(frame, (self.width, self.height))
 

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -11,10 +11,11 @@ try:
 except (ImportError, RuntimeError):
 	ON_PI = False
 
-# Layer 2 is the "preview" (video) layer, hence we skip layers 0, 1 and 2
-BASE_LAYER = 3
-DATA_LAYER = 4
-MESSAGE_LAYER = 5
+class OverlayLayer(Enum):
+	video_feed = 2
+	base = 3
+	data = 4
+	message = 5
 
 class Colour(Enum):
 	# Remember, OpenCV uses BGR(A) not RGB(A)
@@ -225,13 +226,13 @@ class Overlay(ABC):
 	def _on_connect(self, client, userdata, flags, rc):
 		self.on_connect(client, userdata, flags, rc)
 		if ON_PI:
-			self.base_canvas.update_pi_overlay(self.pi_camera, BASE_LAYER)
+			self.base_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.base)
 
 	def _on_message(self, client, userdata, flags):
 		self.on_message(client, userdata, flags)
 		if ON_PI:
-			self.data_canvas.update_pi_overlay(self.pi_camera, DATA_LAYER)
-			self.message_canvas.update_pi_overlay(self.pi_camera, MESSAGE_LAYER)
+			self.data_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.data_layer)
+			self.message_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.message)
 
 	@abstractmethod
 	def on_connect(self, client, userdata, flags, rc):

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -231,6 +231,7 @@ class Overlay(ABC):
 		self.on_message(client, userdata, flags)
 		if ON_PI:
 			self.data_canvas.update_pi_overlay(self.pi_camera, DATA_LAYER)
+			self.message_canvas.update_pi_overlay(self.pi_camera, MESSAGE_LAYER)
 
 	@abstractmethod
 	def on_connect(self, client, userdata, flags, rc):

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -234,7 +234,7 @@ class Overlay(ABC):
 	def _on_message(self, client, userdata, flags):
 		self.on_message(client, userdata, flags)
 		if ON_PI:
-			self.data_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.data_layer)
+			self.data_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.data)
 			self.message_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.message)
 
 	@abstractmethod

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -11,6 +11,9 @@ try:
 except (ImportError, RuntimeError):
 	ON_PI = False
 
+# Top of window is outside the screen to hide title bar
+PI_WINDOW_TOP_LEFT = (0, -20)
+
 class OverlayLayer(Enum):
 	video_feed = 2
 	base = 3
@@ -90,7 +93,7 @@ class Canvas():
 		overlay = pi_camera.add_overlay(self.img, format="rgba", size=(self.width, self.height))
 		overlay.layer = layer
 		overlay.fullscreen = False
-		overlay.window = (0, -20, self.width, self.height)
+		overlay.window = (*PI_WINDOW_TOP_LEFT, self.width, self.height)
 
 		# Rather than creating and swapping out overlays, the proper way to do this would be with overlay.update()
 		# Unfortunately, due to a bug in PiCamera 1.13, this will spam us with errors (which don't matter, but still)
@@ -180,7 +183,7 @@ class Overlay(ABC):
 
 		if ON_PI:
 			# Start displaying video feed. Non blocking, but runs forever.
-			self.pi_camera.start_preview(fullscreen=False, window=(0, -20, self.width, self.height))
+			self.pi_camera.start_preview(fullscreen=False, window=(*PI_WINDOW_TOP_LEFT, self.width, self.height))
 
 		# mqtt loop (does not block)
 		self.client.loop_start()


### PR DESCRIPTION
## Description

This fixes an issue where the camera feed would be extremely slow when running on the Raspberry Pi. Fetching the current frame from the camera was taking approx. 500 ms and adding 3 layers of overlay was taking around 200 ms. That's right, 0.7 seconds *per frame*.

This is fixed by using `picamera` *only on the RPi* to handle displaying the video feed and applying the overlays. This means that the video frame does not have to be loaded from however `picamera` manages it to Python, and (I believe) the overlays can be applied on the GPU instead of through Python. It is hard to measure the current frame time (as it is all managed by picamera), but it seems to be perfectly usable.

Managing overlays through `picamera` is actually what was used to be done pre-`OpenCV` - this meant it brought back the "flickering" issue. I found that the following two changes solved this problem:
- Adding the new overlay to the renderer before removing the old one (seems strange but it seemed to be required)
- Putting the base and data overlays on different `picamera` "layers". They used to both be on the same, which was presumably causing some kind of z-fighting.

Fetching webcam frames, merging with overlays and displaying is still handled by `OpenCV` on computers, as it was before.

## Screenshots

Looks exactly the same as it did before.

## Steps to Test

- Get a Raspberry Pi and camera with the branch cloned
- Start an MQTT broker somewhere, and modify the host address at the bottom of either `overlay_top_strip.py` or `overlay_all_stats.py` appropriately
- Run `mqtt_test.py` from the `data-acquisition-system` repo if you want live data, get BOOST going too if you're extra fancy
- Start an overlay with `python overlay_top_strip.py` or `python_all_stats.py`.
