### PR TITLE
Add host argument to overlays

### DIFF
--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -1,3 +1,4 @@
+import argparse
 import time
 from enum import Enum
 from abc import ABC, abstractmethod
@@ -10,6 +11,11 @@ try:
 	ON_PI = True
 except (ImportError, RuntimeError):
 	ON_PI = False
+
+def get_overlay_args():
+	parser = argparse.ArgumentParser(description="Overlay displaying all (or just many) statistics", add_help=True)
+	parser.add_argument("--host", action="store", type=str, default="localhost", help="Address of the MQTT broker")
+	return parser.parse_args()
 
 class Colour(Enum):
 	# Remember, OpenCV uses BGR(A) not RGB(A)

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -12,8 +12,8 @@ try:
 except (ImportError, RuntimeError):
 	ON_PI = False
 
-def get_overlay_args():
-	parser = argparse.ArgumentParser(description="Overlay displaying all (or just many) statistics", add_help=True)
+def get_overlay_args(overlay_description: str):
+	parser = argparse.ArgumentParser(description=overlay_description, add_help=True)
 	parser.add_argument("--host", action="store", type=str, default="localhost", help="Address of the MQTT broker")
 	return parser.parse_args()
 

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -12,11 +12,6 @@ try:
 except (ImportError, RuntimeError):
 	ON_PI = False
 
-def get_overlay_args(overlay_description: str):
-	parser = argparse.ArgumentParser(description=overlay_description, add_help=True)
-	parser.add_argument("--host", action="store", type=str, default="localhost", help="Address of the MQTT broker")
-	return parser.parse_args()
-
 class Colour(Enum):
 	# Remember, OpenCV uses BGR(A) not RGB(A)
 	white = (255, 255, 255, 255)
@@ -208,3 +203,9 @@ class Overlay(ABC):
 	@abstractmethod
 	def on_message(self, client, userdata, msg):
 		pass
+
+	@staticmethod
+	def get_overlay_args(overlay_description: str):
+		parser = argparse.ArgumentParser(description=overlay_description, add_help=True)
+		parser.add_argument("--host", action="store", type=str, default="localhost", help="Address of the MQTT broker")
+		return parser.parse_args()

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -1,5 +1,5 @@
 import time
-from overlay import Overlay, Colour
+from overlay import Overlay, Colour, get_overlay_args
 import topics
 
 class OverlayAllStats(Overlay):
@@ -145,5 +145,6 @@ class OverlayAllStats(Overlay):
 			self.message_canvas.clear()
 
 if __name__ == '__main__':
+	args = get_overlay_args()
 	my_overlay = OverlayAllStats()
-	my_overlay.connect(ip="localhost")
+	my_overlay.connect(ip=args.host)

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -145,6 +145,6 @@ class OverlayAllStats(Overlay):
 			self.message_canvas.clear()
 
 if __name__ == '__main__':
-	args = get_overlay_args()
+	args = get_overlay_args("Overlay displaying all (or just many) statistics")
 	my_overlay = OverlayAllStats()
 	my_overlay.connect(ip=args.host)

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -1,5 +1,5 @@
 import time
-from overlay import Overlay, Colour, get_overlay_args
+from overlay import Overlay, Colour
 import topics
 
 class OverlayAllStats(Overlay):

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -125,6 +125,6 @@ class OverlayTopStrip(Overlay):
 
 
 if __name__ == '__main__':
-	args = get_overlay_args()
+	args = get_overlay_args("Shows important statistics in a bar at the top of the screen")
 	my_overlay = OverlayTopStrip()
 	my_overlay.connect(ip=args.host)

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -1,5 +1,5 @@
 import time
-from overlay import Overlay, Colour, get_overlay_args
+from overlay import Overlay, Colour
 import topics
 
 
@@ -125,6 +125,6 @@ class OverlayTopStrip(Overlay):
 
 
 if __name__ == '__main__':
-	args = get_overlay_args("Shows important statistics in a bar at the top of the screen")
+	args = Overlay.get_overlay_args("Shows important statistics in a bar at the top of the screen")
 	my_overlay = OverlayTopStrip()
 	my_overlay.connect(ip=args.host)

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -1,5 +1,5 @@
 import time
-from overlay import Overlay, Colour
+from overlay import Overlay, Colour, get_overlay_args
 import topics
 
 
@@ -125,5 +125,6 @@ class OverlayTopStrip(Overlay):
 
 
 if __name__ == '__main__':
+	args = get_overlay_args()
 	my_overlay = OverlayTopStrip()
-	my_overlay.connect(ip="localhost")
+	my_overlay.connect(ip=args.host)


### PR DESCRIPTION
## Description

This was annoying me while doing #26 so I thought I'd fix it for the future.
This PR allows you to specify the MQTT host when running an overlay directly from the command line.

## Screenshots

![image](https://user-images.githubusercontent.com/17876556/76511663-94fac580-64a7-11ea-8ee1-e8916ae04aaa.png)

## Steps to Test

Try the following
```bash
python overlay_top_strip.py -h
python overlay_all_stats.py --host localhost
```
