### PR TITLE
Add data class

### DIFF
--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -14,6 +14,9 @@ V3_MESSAGE = [
 ]
 
 class Data:
+    """ A class to keep track of the most recent bike data for the overlays.
+        Data comes into the class in the V2/V3 MQTT formats and may be accessed
+        by using this class as a dictionary. """
 
     data_types = {
         # DAS data
@@ -33,6 +36,8 @@ class Data:
     }
 
     def __init__(self):
+        # This is by no means a complete list of data fields we could track -
+        # just the ones we currently think we might use on the overlays.
         self.data = {
             # DAS data
             "power": 0,
@@ -50,11 +55,14 @@ class Data:
             "plan_name": "",
         }
 
+        self.message = None
         self.message_received_time = 0
         self.message_duration = 5 # seconds
-        self.message = None
 
     def load_v2_query_string(self, data: str) -> None:
+        """ Updates stored fields with data stored in a V2 query string, e.g.
+            `power=200&cadence=95`. Only the supplied data fields will be
+            updated, the rest remain as they were. """
         terms = data.split("&")
         for term in terms:
             key, value = term.split("=")
@@ -64,26 +72,40 @@ class Data:
             self.data[key] = cast_func(value)
 
     def load_v3_module_data(self, data: str) -> None:
-        pass
+        """ Updates stored fields with data from a V3 sensor module. """
+        # TODO
+        raise NotImplementedError
 
     def load_v3_message(self, data: str) -> None:
+        """ Accepts a V3 message packet which is made accessable via
+            self.get_message. """
         self.message_received_time = time.time()
         self.message = data
 
     def has_message(self) -> bool:
+        """ Returns true if a message is available for display on the overlay,
+            otherwise false (when no message exists, or a message has expired)
+            """
         if not self.message:
             return False
+        # Clear the message and return false if enough time has past since
+        # the message was received
         if time.time() > self.message_received_time + self.message_duration:
             self.message = None
             return False
         return True
 
     def get_message(self) -> Optional[str]:
+        """ Gets the most recent message from the DAShboard. This should only
+            be called if self.has_message returns true. """
         return self.message
 
-    # Overload the [] operator
-    def __getitem__(self, key: str) -> Any:
-        if key in self.data:
-            return self.data[key]
+    def __getitem__(self, field: str) -> Any:
+        """ Gets a the most recent value of a data field. This overloads the
+            [] operator e.g. call with data_intance["power"]. This only allows
+            fetching the data, not assignment. """
+        if field in self.data:
+            return self.data[field]
         else:
-            print(f"WARNING: invalid data key `{key}` used")
+            print(f"WARNING: invalid data field `{field}` used")
+            return None

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -15,6 +15,7 @@ V3_MESSAGE = [
 
 class Data:
     """ A class to keep track of the most recent bike data for the overlays.
+
         Data comes into the class in the V2/V3 MQTT formats and may be accessed
         by using this class as a dictionary. """
 
@@ -60,9 +61,11 @@ class Data:
         self.message_duration = 5 # seconds
 
     def load_v2_query_string(self, data: str) -> None:
-        """ Updates stored fields with data stored in a V2 query string, e.g.
-            `power=200&cadence=95`. Only the supplied data fields will be
-            updated, the rest remain as they were. """
+        """ Updates stored fields with data stored in a V2 query string,
+            e.g. `power=200&cadence=95`.
+
+            Only the supplied data fields will be updated, the rest remain as
+            they were. """
         terms = data.split("&")
         for term in terms:
             key, value = term.split("=")
@@ -84,8 +87,10 @@ class Data:
 
     def has_message(self) -> bool:
         """ Returns true if a message is available for display on the overlay,
-            otherwise false (when no message exists, or a message has expired)
-            """
+            otherwise false.
+
+            Returning false may mean messages have been sent, or the most recent
+            message has expired. """
         if not self.message:
             return False
         # Clear the message and return false if enough time has past since
@@ -96,14 +101,16 @@ class Data:
         return True
 
     def get_message(self) -> Optional[str]:
-        """ Gets the most recent message from the DAShboard. This should only
-            be called if self.has_message returns true. """
+        """ Gets the most recent message from the DAShboard.
+
+            This should only be called if self.has_message returns true. """
         return self.message
 
     def __getitem__(self, field: str) -> Any:
-        """ Gets a the most recent value of a data field. This overloads the
-            [] operator e.g. call with data_intance["power"]. This only allows
-            fetching the data, not assignment. """
+        """ Gets a the most recent value of a data field.
+
+            This overloads the [] operator e.g. call with data_intance["power"].
+            This only allows fetching the data, not assignment. """
         if field in self.data:
             return self.data[field]
         else:

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -43,6 +43,7 @@ class Data:
             "zdist": 0,
             "plan_name": "",
         }
+        self._has_new_data = False
 
     def load_v2_query_string(self, data: str) -> None:
         terms = data.split("&")
@@ -52,9 +53,16 @@ class Data:
                 continue
             cast_func = self.data_types[key]
             self.data[key] = cast_func(value)
+        self._has_new_data = True
 
     def load_v3_module_data(self, data: str) -> None:
         pass
+
+    def has_new_data(self) -> bool:
+        if self._has_new_data:
+            self._has_new_data = False
+            return True
+        return False
 
     # Overload the [] operator
     def __getitem__(self, key: str) -> Any:

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -5,6 +5,7 @@ V2_DATA_TOPICS = [
     str(topics.DAS.data),
     str(topics.PowerModel.recommended_sp),
     str(topics.PowerModel.predicted_max_speed),
+    str(topics.PowerModel.plan_name),
 ]
 
 class Data:

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -1,6 +1,6 @@
 import time
 from typing import Any, Optional
-import CameraOverlay.topics as topics
+import topics as topics
 
 V2_DATA_TOPICS = [
     str(topics.DAS.data),

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -1,4 +1,5 @@
-from typing import Any
+import time
+from typing import Any, Optional
 import CameraOverlay.topics as topics
 
 V2_DATA_TOPICS = [
@@ -6,6 +7,10 @@ V2_DATA_TOPICS = [
     str(topics.PowerModel.recommended_sp),
     str(topics.PowerModel.predicted_max_speed),
     str(topics.PowerModel.plan_name),
+]
+
+V3_MESSAGE = [
+    str(topics.DAShboard.receive_message)
 ]
 
 class Data:
@@ -46,6 +51,10 @@ class Data:
         }
         self._has_new_data = False
 
+        self.message_recieved_time = 0
+        self.message_duration = 5 # seconds
+        self.message = None
+
     def load_v2_query_string(self, data: str) -> None:
         terms = data.split("&")
         for term in terms:
@@ -59,11 +68,26 @@ class Data:
     def load_v3_module_data(self, data: str) -> None:
         pass
 
+    def load_v3_message(self, data: str) -> None:
+        self.message_recieved_time = time.time()
+        self.message = data
+
     def has_new_data(self) -> bool:
         if self._has_new_data:
             self._has_new_data = False
             return True
         return False
+
+    def has_message(self) -> bool:
+        if not self.message:
+            return False
+        if time.time() > self.message_recieved_time + self.message_duration:
+            self.message = None
+            return False
+        return True
+
+    def get_message(self) -> Optional[str]:
+        return self.message
 
     # Overload the [] operator
     def __getitem__(self, key: str) -> Any:

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -49,7 +49,6 @@ class Data:
             "zdist": 0,
             "plan_name": "",
         }
-        self._has_new_data = False
 
         self.message_recieved_time = 0
         self.message_duration = 5 # seconds
@@ -63,7 +62,6 @@ class Data:
                 continue
             cast_func = self.data_types[key]
             self.data[key] = cast_func(value)
-        self._has_new_data = True
 
     def load_v3_module_data(self, data: str) -> None:
         pass
@@ -71,12 +69,6 @@ class Data:
     def load_v3_message(self, data: str) -> None:
         self.message_recieved_time = time.time()
         self.message = data
-
-    def has_new_data(self) -> bool:
-        if self._has_new_data:
-            self._has_new_data = False
-            return True
-        return False
 
     def has_message(self) -> bool:
         if not self.message:

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -50,7 +50,7 @@ class Data:
             "plan_name": "",
         }
 
-        self.message_recieved_time = 0
+        self.message_received_time = 0
         self.message_duration = 5 # seconds
         self.message = None
 
@@ -67,13 +67,13 @@ class Data:
         pass
 
     def load_v3_message(self, data: str) -> None:
-        self.message_recieved_time = time.time()
+        self.message_received_time = time.time()
         self.message = data
 
     def has_message(self) -> bool:
         if not self.message:
             return False
-        if time.time() > self.message_recieved_time + self.message_duration:
+        if time.time() > self.message_received_time + self.message_duration:
             self.message = None
             return False
         return True

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -2,9 +2,9 @@ from typing import Any
 import CameraOverlay.topics as topics
 
 V2_DATA_TOPICS = [
-    topics.DAS.data,
-    topics.PowerModel.recommended_sp,
-    topics.PowerModel.predicted_max_speed,
+    str(topics.DAS.data),
+    str(topics.PowerModel.recommended_sp),
+    str(topics.PowerModel.predicted_max_speed),
 ]
 
 class Data:
@@ -49,7 +49,6 @@ class Data:
         for term in terms:
             key, value = term.split("=")
             if key not in self.data_types:
-                print(f"WARNING: invalid data key `{key}` used")
                 continue
             cast_func = self.data_types[key]
             self.data[key] = cast_func(value)

--- a/CameraOverlay/data.py
+++ b/CameraOverlay/data.py
@@ -1,0 +1,65 @@
+from typing import Any
+import CameraOverlay.topics as topics
+
+V2_DATA_TOPICS = [
+    topics.DAS.data,
+    topics.PowerModel.recommended_sp,
+    topics.PowerModel.predicted_max_speed,
+]
+
+class Data:
+
+    data_types = {
+        # DAS data
+        "power": int,
+        "cadence": int,
+        "gps": int,
+        "gps_speed": float,
+        "reed_velocity": float,
+        "reed_distance": float,
+
+        # Power model data
+        "rec_power": float,
+        "rec_speed": float,
+        "predicted_max_speed": float,
+        "zdist": float,
+        "plan_name": str,
+    }
+
+    def __init__(self):
+        self.data = {
+            # DAS data
+            "power": 0,
+            "cadence": 0,
+            "gps": 0,
+            "gps_speed": 0,
+            "reed_velocity": 0,
+            "reed_distance": 0,
+
+            # Power model data
+            "rec_power": 0,
+            "rec_speed": 0,
+            "predicted_max_speed": 0,
+            "zdist": 0,
+            "plan_name": "",
+        }
+
+    def load_v2_query_string(self, data: str) -> None:
+        terms = data.split("&")
+        for term in terms:
+            key, value = term.split("=")
+            if key not in self.data_types:
+                print(f"WARNING: invalid data key `{key}` used")
+                continue
+            cast_func = self.data_types[key]
+            self.data[key] = cast_func(value)
+
+    def load_v3_module_data(self, data: str) -> None:
+        pass
+
+    # Overload the [] operator
+    def __getitem__(self, key: str) -> Any:
+        if key in self.data:
+            return self.data[key]
+        else:
+            print(f"WARNING: invalid data key `{key}` used")

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -179,6 +179,15 @@ class Overlay(ABC):
 				# Create and display the frame using OpenCV
 				self.show_opencv_frame()
 
+	def subscribe_to_topic_list(self, topics):
+		# https://pypi.org/project/paho-mqtt/#subscribe-unsubscribe
+		# Basically, construct a list in the format [("topic1", qos1), ("topic2", qos2), ...]
+		topic_values = list(map(str, topics))
+		at_most_once_qos = [0]*len(topics)
+
+		topics_qos = list(zip(topic_values, at_most_once_qos))
+		self.client.subscribe(topics_qos)
+
 	# Calculate max speed
 	def actual_max(self, cur_speed):
 		return max(self.max_speed, cur_speed)
@@ -191,6 +200,7 @@ class Overlay(ABC):
 		print("Disconnected from broker")
 
 	def _on_connect(self, client, userdata, flags, rc):
+		self.subscribe_to_topic_list(V2_DATA_TOPICS)
 		self.on_connect(client, userdata, flags, rc)
 		if ON_PI:
 			self.base_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.base)

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -168,13 +168,20 @@ class Overlay(ABC):
 			if time.time() > prev_data_update + self.data_update_interval:
 				prev_data_update = time.time()
 
+				# Update the data overlay with latest information
 				self.update_data_layer()
+
 				if ON_PI:
+					# Update the overlay images on picamera. Picamera will
+					# retain the overlay images until updated, so we only need
+					# to do this once per overlay update.
 					self.data_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.data)
 					self.message_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.message)
 
 			if not ON_PI:
-				# Create and display the frame using OpenCV
+				# Create and display the frame using OpenCV.
+				# This function fetches the most up-to-date overlay, as OpenCV
+				# needs us to manually add it to each frame.
 				self.show_opencv_frame()
 
 	def subscribe_to_topic_list(self, topics):
@@ -212,10 +219,16 @@ class Overlay(ABC):
 
 	@abstractmethod
 	def on_connect(self, client, userdata, flags, rc):
+		""" Called automatically when the overlay connects successfully to the
+			MQTT broker. Overlay implementations may override for one-off
+			operations (e.g. drawing self.base_canvas) """
 		pass
 
 	@abstractmethod
 	def update_data_layer(self):
+		""" Called automatically at a regular interval defined by
+			self.data_update_interval. Overlay implementations should override
+			this method with code which updates self.data_canvas. """
 		pass
 
 	@staticmethod

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -142,7 +142,7 @@ class Overlay(ABC):
 			"reed_velocity": 0,
 
 			# power model data
-			"max_speed": 0,
+			"predicted_max_speed": 0,
 			"rec_power": 0,
 			"rec_speed": 0,
 			"zdist": 0,
@@ -162,7 +162,7 @@ class Overlay(ABC):
 			# power model data
 			"rec_power": float,
 			"rec_speed": float,
-			"max_speed": float,
+			"predicted_max_speed": float,
 			"zdist": float,
 			"plan_name": str,
 		}

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -7,7 +7,6 @@ import numpy as np
 import paho.mqtt.client as mqtt
 
 from data import Data, V2_DATA_TOPICS, V3_MESSAGE
-import topics as topics
 
 try:
 	from picamera import PiCamera

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -6,7 +6,7 @@ import cv2
 import numpy as np
 import paho.mqtt.client as mqtt
 
-from CameraOverlay.data import Data, V2_DATA_TOPICS
+from CameraOverlay.data import Data, V2_DATA_TOPICS, V3_MESSAGE
 import CameraOverlay.topics as topics
 
 try:
@@ -200,7 +200,7 @@ class Overlay(ABC):
 		print("Disconnected from broker")
 
 	def _on_connect(self, client, userdata, flags, rc):
-		self.subscribe_to_topic_list(V2_DATA_TOPICS)
+		self.subscribe_to_topic_list(V2_DATA_TOPICS + V3_MESSAGE)
 		self.on_connect(client, userdata, flags, rc)
 		if ON_PI:
 			self.base_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.base)
@@ -209,6 +209,8 @@ class Overlay(ABC):
 		payload = msg.payload.decode("utf-8")
 		if msg.topic in V2_DATA_TOPICS:
 			self.data.load_v2_query_string(payload)
+		elif msg.topic in V3_MESSAGE:
+			self.data.load_v3_message(payload)
 
 	@abstractmethod
 	def on_connect(self, client, userdata, flags, rc):

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -165,11 +165,10 @@ class Overlay(ABC):
 		prev_data_update = 0 # time that we last updated the data layer
 		while True:
 
-			# Update the data overlay only if we have waited enough time and there is new data
-			data_update_due = time.time() > prev_data_update + self.data_update_interval
-			if data_update_due and self.data.has_new_data():
-
+			# Update the data overlay only if we have waited enough time
+			if time.time() > prev_data_update + self.data_update_interval:
 				prev_data_update = time.time()
+
 				self.update_data_layer()
 				if ON_PI:
 					self.data_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.data)

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -60,6 +60,7 @@ class Canvas():
 
 	def draw_text(self, text, coord, size=1.5, colour=Colour.black):
 		""" Draws text to the canvas.
+
 		    The bottom left corner of the text is given by the tuple coord.
 		    (the top left of the screen is the origin) """
 		colour = Canvas._get_colour_tuple(colour)
@@ -72,13 +73,15 @@ class Canvas():
 
 	def draw_rect(self, top_left, bottom_right, colour=Colour.black):
 		""" Draws a rectangle to the canvas.
+
 		    top_left and bottom_right are tuples, and specify the dimensions of the rectangle
 		    (the top left of the screen is the origin) """
 		colour = Canvas._get_colour_tuple(colour)
 		cv2.rectangle(self.img, top_left, bottom_right, colour, thickness=cv2.FILLED)
 
 	def copy_to(self, dest):
-		""" Writes the contents of self.img over dest, accounting for transparency
+		""" Writes the contents of self.img over dest, accounting for transparency.
+
 		    Use this method to put the overlay contents over the video feed """
 		# Extract the alpha mask of the BGRA canvas, convert to BGR
 		blue, green, red, alpha = cv2.split(self.img)
@@ -220,15 +223,19 @@ class Overlay(ABC):
 	@abstractmethod
 	def on_connect(self, client, userdata, flags, rc):
 		""" Called automatically when the overlay connects successfully to the
-			MQTT broker. Overlay implementations may override for one-off
-			operations (e.g. drawing self.base_canvas) """
+			MQTT broker.
+
+			Overlay implementations may override for one-off operations
+			(e.g. drawing self.base_canvas) """
 		pass
 
 	@abstractmethod
 	def update_data_layer(self):
 		""" Called automatically at a regular interval defined by
-			self.data_update_interval. Overlay implementations should override
-			this method with code which updates self.data_canvas. """
+			self.data_update_interval.
+
+			Overlay implementations should override this method with code which
+			updates self.data_canvas. """
 		pass
 
 	@staticmethod

--- a/CameraOverlay/overlay.py
+++ b/CameraOverlay/overlay.py
@@ -6,8 +6,8 @@ import cv2
 import numpy as np
 import paho.mqtt.client as mqtt
 
-from CameraOverlay.data import Data, V2_DATA_TOPICS, V3_MESSAGE
-import CameraOverlay.topics as topics
+from data import Data, V2_DATA_TOPICS, V3_MESSAGE
+import topics as topics
 
 try:
 	from picamera import PiCamera

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -9,7 +9,7 @@ class OverlayAllStats(Overlay):
 			topics.DAS.data,
 			topics.DAS.stop,
 			topics.PowerModel.recommended_sp,
-			topics.PowerModel.max_speed,
+			topics.PowerModel.predicted_max_speed,
 			topics.DAShboard.receive_message,
 	]
 
@@ -51,9 +51,9 @@ class OverlayAllStats(Overlay):
 			parsed_data = self.parse_data(msg.payload)
 			self.data["rec_power"] = float(parsed_data["rec_power"])
 			self.data["rec_speed"] = float(parsed_data["rec_speed"])
-		elif topic == str(topics.PowerModel.max_speed):
-			max_speed = str(msg.payload.decode("utf-8"))
-			self.data["max_speed"] = float(max_speed)
+		elif topic == str(topics.PowerModel.predicted_max_speed):
+			parsed_data = self.parse_data(msg.payload)
+			self.data["predicted_max_speed"] = float(parsed_data["predicted_max_speed"])
 		elif topic == str(topics.DAS.data):
 			data = msg.payload
 			parsed_data = self.parse_data(data)
@@ -96,7 +96,7 @@ class OverlayAllStats(Overlay):
 				# Display speed
 				if self.data["reed_velocity"] != 0:
 					# Max Speed
-					max_speed = self.data["max_speed"]
+					max_speed = self.data["predicted_max_speed"]
 					max_speed_text = "{0} km/h".format(round(max_speed, 2))
 					max_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 2)
 					self.data_canvas.draw_text(max_speed_text, max_speed_pos, size=2.5)

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -1,6 +1,6 @@
 import time
-from CameraOverlay.overlay import Overlay, Colour
-import CameraOverlay.topics as topics
+from overlay import Overlay, Colour
+import topics as topics
 
 class OverlayAllStats(Overlay):
 

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -1,17 +1,8 @@
 import time
-from overlay import Overlay, Colour
-import topics
+from CameraOverlay.overlay import Overlay, Colour
+import CameraOverlay.topics as topics
 
 class OverlayAllStats(Overlay):
-
-	topics = [
-			topics.DAS.start,
-			topics.DAS.data,
-			topics.DAS.stop,
-			topics.PowerModel.recommended_sp,
-			topics.PowerModel.predicted_max_speed,
-			topics.DAShboard.receive_message,
-	]
 
 	def __init__(self):
 		super(OverlayAllStats, self).__init__()
@@ -21,14 +12,6 @@ class OverlayAllStats(Overlay):
 
 	def on_connect(self, client, userdata, flags, rc):
 		print('Connected with rc: {}'.format(rc))
-
-		# https://pypi.org/project/paho-mqtt/#subscribe-unsubscribe
-		# Basically, construct a list in the format [("topic1", qos1), ("topic2", qos2), ...]
-		topic_values = list(map(str, OverlayAllStats.topics))
-		at_most_once_qos = [0]*len(OverlayAllStats.topics)
-
-		topics_qos = list(zip(topic_values, at_most_once_qos))
-		client.subscribe(topics_qos)
 
 		# Add static text
 		self.base_canvas.draw_text("REC Power:", (5, self.text_height * 1))
@@ -42,107 +25,67 @@ class OverlayAllStats(Overlay):
 		self.base_canvas.draw_text("REC:", (speed_x, self.height - self.speed_height * 1), size=2.5)
 		self.base_canvas.draw_text("MAX:", (speed_x, self.height - self.speed_height * 2), size=2.5)
 
-	def on_message(self, client, userdata, msg):
-		topic = msg.topic
-		print(topic + " " + str(msg.payload.decode("utf-8")))
-		current_time = round(time.time(), 2)
+	def update_data_layer(self):
+		self.data_canvas.clear()
+		self.message_canvas.clear()
 
-		if topic == str(topics.PowerModel.recommended_sp):
-			parsed_data = self.parse_data(msg.payload)
-			self.data["rec_power"] = float(parsed_data["rec_power"])
-			self.data["rec_speed"] = float(parsed_data["rec_speed"])
-		elif topic == str(topics.PowerModel.predicted_max_speed):
-			parsed_data = self.parse_data(msg.payload)
-			self.data["predicted_max_speed"] = float(parsed_data["predicted_max_speed"])
-		elif topic == str(topics.DAS.data):
-			data = msg.payload
-			parsed_data = self.parse_data(data)
-			print(str(parsed_data))
-			self.data["power"] += int(parsed_data["power"])
-			self.data["cadence"] += int(parsed_data["cadence"])
-			if int(parsed_data["gps"]) == 1:
-				self.data["gps_speed"] += float(parsed_data["gps_speed"])
-			self.data["reed_distance"] += float(parsed_data["reed_distance"])
-			self.data["reed_velocity"] += float(parsed_data["reed_velocity"])
-			self.data["count"] = self.data["count"] + 1
-			total_time = current_time - self.start_time
-			update_time = 0.5
+		# Display power
+		if self.data["power"] != 0:
+			power = self.data["power"]
+			rec_power = self.data["rec_power"]
+			tolerance = 0.05
+			# Display recommended power
+			self.data_canvas.draw_text("{0}".format(round(rec_power, 2)), (340, self.text_height * 1))
+			# Display power
+			if power > (rec_power + (rec_power * tolerance)):
+				power_colour = Colour.red
+			elif power > rec_power:
+				power_colour = Colour.green
+			else:
+				power_colour = Colour.black
+			self.data_canvas.draw_text("{0}".format(round(power, 2)), (340, self.text_height * 2), colour=power_colour)
 
-			if total_time >= update_time:
-				self.start_time = current_time
-				self.data_canvas.clear()
+		# Display cadence
+		if self.data["cadence"] != 0:
+			cadence = self.data["cadence"]
+			self.data_canvas.draw_text("{0}".format(round(cadence, 2)), (340, self.text_height * 3))
 
-				# Display power
-				if self.data["power"] != 0:
-					power = self.data["power"] / self.data["count"]
-					rec_power = self.data["rec_power"]
-					tolerance = 0.05
-					# Display recommended power
-					self.data_canvas.draw_text("{0}".format(round(rec_power, 2)), (340, self.text_height * 1))
-					# Display power
-					if power > (rec_power + (rec_power * tolerance)):
-						power_colour = Colour.red
-					elif power > rec_power:
-						power_colour = Colour.green
-					else:
-						power_colour = Colour.black
-					self.data_canvas.draw_text("{0}".format(round(power, 2)), (340, self.text_height * 2), colour=power_colour)
+		# Display speed
+		if self.data["reed_velocity"] != 0:
+			# Max Speed
+			max_speed = self.data["predicted_max_speed"]
+			max_speed_text = "{0} km/h".format(round(max_speed, 2))
+			max_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 2)
+			self.data_canvas.draw_text(max_speed_text, max_speed_pos, size=2.5)
 
-				# Display cadence
-				if self.data["cadence"] != 0:
-					cadence = self.data["cadence"] / self.data["count"]
-					self.data_canvas.draw_text("{0}".format(round(cadence, 2)), (340, self.text_height * 3))
+			# Recommended speed
+			rec_speed = self.data["rec_speed"]
+			rec_speed_text = "{0} km/h".format(round(rec_speed, 2))
+			rec_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 1)
+			self.data_canvas.draw_text(rec_speed_text, rec_speed_pos, size=2.5)
 
-				# Display speed
-				if self.data["reed_velocity"] != 0:
-					# Max Speed
-					max_speed = self.data["predicted_max_speed"]
-					max_speed_text = "{0} km/h".format(round(max_speed, 2))
-					max_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 2)
-					self.data_canvas.draw_text(max_speed_text, max_speed_pos, size=2.5)
+			# Actual speed
+			speed = self.data["reed_velocity"]
+			speed_text = "{0} km/h".format(round(speed, 2))
+			speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 0)
+			tolerance = 0.05
+			if speed > (rec_speed + (rec_speed * tolerance)):
+				speed_colour = Colour.red
+			elif speed > rec_speed:
+				speed_colour = Colour.green
+			else:
+				speed_colour = Colour.black
+			self.data_canvas.draw_text(speed_text, speed_pos, colour=speed_colour, size=2.5)
 
-					# Recommended speed
-					rec_speed = self.data["rec_speed"]
-					rec_speed_text = "{0} km/h".format(round(rec_speed, 2))
-					rec_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 1)
-					self.data_canvas.draw_text(rec_speed_text, rec_speed_pos, size=2.5)
-
-					# Actual speed
-					speed = self.data["reed_velocity"] / self.data["count"]
-					speed_text = "{0} km/h".format(round(speed, 2))
-					speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 0)
-					tolerance = 0.05
-					if speed > (rec_speed + (rec_speed * tolerance)):
-						speed_colour = Colour.red
-					elif speed > rec_speed:
-						speed_colour = Colour.green
-					else:
-						speed_colour = Colour.black
-					self.data_canvas.draw_text(speed_text, speed_pos, colour=speed_colour, size=2.5)
-
-				# Display reed_distance (distance travelled)
-				if self.data["reed_distance"] != 0:
-					reed_distance = self.data["reed_distance"] / self.data["count"]
-					self.data_canvas.draw_text("{0}".format(round(reed_distance, 2)), (340, self.text_height * 4))
-
-				# Reset variables
-				self.data["power"] = 0
-				self.data["cadence"] = 0
-				self.data["gps_speed"] = 0
-				self.data["reed_velocity"] = 0
-				self.data["reed_distance"] = 0
-				self.data["count"] = 0
+		# Display reed_distance (distance travelled)
+		if self.data["reed_distance"] != 0:
+			reed_distance = self.data["reed_distance"]
+			self.data_canvas.draw_text("{0}".format(round(reed_distance, 2)), (340, self.text_height * 4))
 		
-		elif topic == str(topics.DAShboard.receive_message):
-			self.message_received_time = time.time()
-			message = msg.payload.decode("utf-8")
-			self.message_canvas.clear()
-
-			# Display Message
+		# Display messages from DAShboard
+		if self.data.has_message():
+			message = self.data.get_message()
 			self.message_canvas.draw_text(message, (190, self.text_height * 5), size=1, colour=Colour.red)
-
-		if time.time() - self.message_received_time >= 5:
-			self.message_canvas.clear()
 
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("Overlay displaying all (or just many) statistics")

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -1,6 +1,5 @@
 import time
 from overlay import Overlay, Colour
-import topics as topics
 
 class OverlayAllStats(Overlay):
 

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -28,63 +28,73 @@ class OverlayAllStats(Overlay):
 		self.data_canvas.clear()
 		self.message_canvas.clear()
 
-		# Display power
 		if self.data["power"] != 0:
-			power = self.data["power"]
-			rec_power = self.data["rec_power"]
-			tolerance = 0.05
-			# Display recommended power
-			self.data_canvas.draw_text("{0}".format(round(rec_power, 2)), (340, self.text_height * 1))
-			# Display power
-			if power > (rec_power + (rec_power * tolerance)):
-				power_colour = Colour.red
-			elif power > rec_power:
-				power_colour = Colour.green
-			else:
-				power_colour = Colour.black
-			self.data_canvas.draw_text("{0}".format(round(power, 2)), (340, self.text_height * 2), colour=power_colour)
+			self.draw_power_rec_power()
 
-		# Display cadence
 		if self.data["cadence"] != 0:
-			cadence = self.data["cadence"]
-			self.data_canvas.draw_text("{0}".format(round(cadence, 2)), (340, self.text_height * 3))
+			self.draw_cadence()
 
-		# Display speed
 		if self.data["reed_velocity"] != 0:
-			# Max Speed
-			max_speed = self.data["predicted_max_speed"]
-			max_speed_text = "{0} km/h".format(round(max_speed, 2))
-			max_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 2)
-			self.data_canvas.draw_text(max_speed_text, max_speed_pos, size=2.5)
+			self.draw_max_rec_reed_velocity()
 
-			# Recommended speed
-			rec_speed = self.data["rec_speed"]
-			rec_speed_text = "{0} km/h".format(round(rec_speed, 2))
-			rec_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 1)
-			self.data_canvas.draw_text(rec_speed_text, rec_speed_pos, size=2.5)
-
-			# Actual speed
-			speed = self.data["reed_velocity"]
-			speed_text = "{0} km/h".format(round(speed, 2))
-			speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 0)
-			tolerance = 0.05
-			if speed > (rec_speed + (rec_speed * tolerance)):
-				speed_colour = Colour.red
-			elif speed > rec_speed:
-				speed_colour = Colour.green
-			else:
-				speed_colour = Colour.black
-			self.data_canvas.draw_text(speed_text, speed_pos, colour=speed_colour, size=2.5)
-
-		# Display reed_distance (distance travelled)
 		if self.data["reed_distance"] != 0:
-			reed_distance = self.data["reed_distance"]
-			self.data_canvas.draw_text("{0}".format(round(reed_distance, 2)), (340, self.text_height * 4))
+			self.draw_distance()
 		
-		# Display messages from DAShboard
 		if self.data.has_message():
-			message = self.data.get_message()
-			self.message_canvas.draw_text(message, (190, self.text_height * 5), size=1, colour=Colour.red)
+			self.draw_messages()
+
+	def draw_power_rec_power(self):
+		power = self.data["power"]
+		rec_power = self.data["rec_power"]
+		tolerance = 0.05
+		# Display recommended power
+		self.data_canvas.draw_text("{0}".format(round(rec_power, 2)), (340, self.text_height * 1))
+		# Display power
+		if power > (rec_power + (rec_power * tolerance)):
+			power_colour = Colour.red
+		elif power > rec_power:
+			power_colour = Colour.green
+		else:
+			power_colour = Colour.black
+		self.data_canvas.draw_text("{0}".format(round(power, 2)), (340, self.text_height * 2), colour=power_colour)
+
+	def draw_cadence(self):
+		cadence = self.data["cadence"]
+		self.data_canvas.draw_text("{0}".format(round(cadence, 2)), (340, self.text_height * 3))
+
+	def draw_max_rec_reed_velocity(self):
+		# Max Speed
+		max_speed = self.data["predicted_max_speed"]
+		max_speed_text = "{0} km/h".format(round(max_speed, 2))
+		max_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 2)
+		self.data_canvas.draw_text(max_speed_text, max_speed_pos, size=2.5)
+
+		# Recommended speed
+		rec_speed = self.data["rec_speed"]
+		rec_speed_text = "{0} km/h".format(round(rec_speed, 2))
+		rec_speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 1)
+		self.data_canvas.draw_text(rec_speed_text, rec_speed_pos, size=2.5)
+
+		# Actual speed
+		speed = self.data["reed_velocity"]
+		speed_text = "{0} km/h".format(round(speed, 2))
+		speed_pos = (self.width // 2 - 70, self.height - self.speed_height * 0)
+		tolerance = 0.05
+		if speed > (rec_speed + (rec_speed * tolerance)):
+			speed_colour = Colour.red
+		elif speed > rec_speed:
+			speed_colour = Colour.green
+		else:
+			speed_colour = Colour.black
+		self.data_canvas.draw_text(speed_text, speed_pos, colour=speed_colour, size=2.5)
+
+	def draw_distance(self):
+		reed_distance = self.data["reed_distance"]
+		self.data_canvas.draw_text("{0}".format(round(reed_distance, 2)), (340, self.text_height * 4))
+
+	def draw_messages(self):
+		message = self.data.get_message()
+		self.message_canvas.draw_text(message, (190, self.text_height * 5), size=1, colour=Colour.red)
 
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("Overlay displaying all (or just many) statistics")

--- a/CameraOverlay/overlay_all_stats.py
+++ b/CameraOverlay/overlay_all_stats.py
@@ -145,6 +145,6 @@ class OverlayAllStats(Overlay):
 			self.message_canvas.clear()
 
 if __name__ == '__main__':
-	args = get_overlay_args("Overlay displaying all (or just many) statistics")
+	args = Overlay.get_overlay_args("Overlay displaying all (or just many) statistics")
 	my_overlay = OverlayAllStats()
 	my_overlay.connect(ip=args.host)

--- a/CameraOverlay/overlay_blank.py
+++ b/CameraOverlay/overlay_blank.py
@@ -19,4 +19,4 @@ class OverlayBlank(Overlay):
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("An empty, example overlay")
 	my_overlay = OverlayBlank()
-	my_overlay.connect(ip="192.168.1.154")
+	my_overlay.connect(ip=args.host)

--- a/CameraOverlay/overlay_blank.py
+++ b/CameraOverlay/overlay_blank.py
@@ -11,13 +11,12 @@ class OverlayBlank(Overlay):
 		# To draw static text/whatever onto the overlay, draw on the base canvas
 		self.base_canvas.draw_text("Blank overlay", (10, self.height - 10), 4, colour=Colour.white)
 
-	def on_message(self, client, userdata, msg):
-		topic = msg.topic
-		print(topic + " " + str(msg.payload.decode("utf-8")))
+	def update_data_layer(self):
+		self.data_canvas.clear()
 
 		# Content that changes each frame should be drawn to self.data_canvas here
 
-
 if __name__ == '__main__':
+	args = Overlay.get_overlay_args("An empty, example overlay")
 	my_overlay = OverlayBlank()
-	my_overlay.connect(ip="localhost")
+	my_overlay.connect(ip="192.168.1.154")

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -5,15 +5,6 @@ import CameraOverlay.topics as topics
 
 class OverlayTopStrip(Overlay):
 
-	topics = [
-			topics.DAS.start,
-			topics.DAS.data,
-			topics.DAS.stop,
-			topics.PowerModel.recommended_sp,
-			topics.PowerModel.predicted_max_speed,
-			topics.PowerModel.plan_name,
-	]
-
 	def __init__(self):
 		super(OverlayTopStrip, self).__init__()
 
@@ -29,14 +20,6 @@ class OverlayTopStrip(Overlay):
 
 	def on_connect(self, client, userdata, flags, rc):
 		print("Connected with rc: " + str(rc))
-
-		# https://pypi.org/project/paho-mqtt/#subscribe-unsubscribe
-		# Basically, construct a list in the format [("topic1", qos1), ("topic2", qos2), ...]
-		topic_values = list(map(str, OverlayTopStrip.topics))
-		at_most_once_qos = [0]*len(OverlayTopStrip.topics)
-
-		topics_qos = list(zip(topic_values, at_most_once_qos))
-		client.subscribe(topics_qos)
 
 		self.base_canvas.draw_rect((0, 0), (self.top_box_width, self.top_box_height))
 		self.base_canvas.draw_text("T:", (0, self.top_text_pos), colour=Colour.white)

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -37,38 +37,48 @@ class OverlayTopStrip(Overlay):
 		time_string = "{:0>2}:{:0>2}".format(int(minutes), int(seconds))
 		self.data_canvas.draw_text(time_string, (50, self.top_text_pos), colour=Colour.white)
 
-		# Display power
 		if self.data["power"] != 0:
-			power = self.data["power"]
-			rec_power = self.data["rec_power"]
-			# Display recommended power
-			self.data_canvas.draw_text("{0}".format(round(rec_power, 0)), (600, self.top_text_pos), colour=Colour.white)
-			# Display power (no colour change)
-			self.data_canvas.draw_text("P: {0}".format(round(power, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y), size=self.bottom_text_size, colour=Colour.red)
+			self.draw_power_rec_power()
 
-		# Display speed
 		if self.data["gps"] == 1:
 			if self.data["gps_speed"] != 0:
-				# Predicted max speed
-				pred_max_speed = self.data["predicted_max_speed"]
-				self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 1)), (890, self.top_text_pos), colour=Colour.white)
-
-				# Actual speed (no colour change)
-				speed = self.data["gps_speed"]
-				self.data_canvas.draw_text("S: {0}".format(round(speed, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y - self.bottom_text_height), size=self.bottom_text_size, colour=Colour.red)
-
-				# Actual max speed
-				self.data_canvas.draw_text("{0}".format(int(self.actual_max(speed))), (1120, self.top_text_pos), colour=Colour.white)
+				self.draw_speed_max_speed()
 
 		# Display zone distance left (bugged)
 		if self.data["zdist"] != 0:
-			zdist_left = self.data["zdist"]
-			self.data_canvas.draw_text("{0}".format(int(zdist_left)), (360, self.top_text_pos), colour=Colour.white)
+			self.draw_zone_dist()
 
 		# Display plan name and clear after 15 secs
 		if self.data["plan_name"] != '' and time.time() - self.start_time <= 15:
-			plan_name = self.data["plan_name"]
-			self.data_canvas.draw_text(plan_name, (0, self.height - 8), colour=Colour.red)
+			self.draw_plan_name()
+
+	def draw_power_rec_power(self):
+		power = self.data["power"]
+		rec_power = self.data["rec_power"]
+		# Display recommended power
+		self.data_canvas.draw_text("{0}".format(round(rec_power, 0)), (600, self.top_text_pos), colour=Colour.white)
+		# Display power (no colour change)
+		self.data_canvas.draw_text("P: {0}".format(round(power, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y), size=self.bottom_text_size, colour=Colour.red)
+
+	def draw_speed_max_speed(self):
+		# Predicted max speed
+		pred_max_speed = self.data["predicted_max_speed"]
+		self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 1)), (890, self.top_text_pos), colour=Colour.white)
+
+		# Actual speed (no colour change)
+		speed = self.data["gps_speed"]
+		self.data_canvas.draw_text("S: {0}".format(round(speed, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y - self.bottom_text_height), size=self.bottom_text_size, colour=Colour.red)
+
+		# Actual max speed
+		self.data_canvas.draw_text("{0}".format(int(self.actual_max(speed))), (1120, self.top_text_pos), colour=Colour.white)
+
+	def draw_zone_dist(self):
+		zdist_left = self.data["zdist"]
+		self.data_canvas.draw_text("{0}".format(int(zdist_left)), (360, self.top_text_pos), colour=Colour.white)
+
+	def draw_plan_name(self):
+		plan_name = self.data["plan_name"]
+		self.data_canvas.draw_text(plan_name, (0, self.height - 8), colour=Colour.red)
 
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("Shows important statistics in a bar at the top of the screen")

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -10,7 +10,7 @@ class OverlayTopStrip(Overlay):
 			topics.DAS.data,
 			topics.DAS.stop,
 			topics.PowerModel.recommended_sp,
-			topics.PowerModel.max_speed,
+			topics.PowerModel.predicted_max_speed,
 			topics.PowerModel.plan_name,
 	]
 
@@ -53,8 +53,8 @@ class OverlayTopStrip(Overlay):
 			self.data["rec_power"] = int(parsed_data["rec_power"])
 			self.data["zdist"] = int(parsed_data["zdist"])
 		elif msg.topic == str(topics.PowerModel.predicted_max_speed):
-			max_speed = str(msg.payload.decode("utf-8"))
-			self.data["max_speed"] = float(max_speed)
+			parsed_data = self.parse_data(msg.payload)
+			self.data["predicted_max_speed"] = float(parsed_data["predicted_max_speed"])
 		elif msg.topic == str(topics.PowerModel.plan_name):
 			parsed_data = self.parse_data(msg.payload)
 			self.data["plan_name"] = str(parsed_data["plan_name"])
@@ -96,8 +96,8 @@ class OverlayTopStrip(Overlay):
 				if int(parsed_data["gps"]) == 1:
 					if self.data["gps_speed"] != 0:
 						# Predicted max speed
-						pred_max_speed = self.data["max_speed"]
-						self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 2)), (890, self.top_text_pos), colour=Colour.white)
+						pred_max_speed = self.data["predicted_max_speed"]
+						self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 1)), (890, self.top_text_pos), colour=Colour.white)
 
 						# Actual speed (no colour change)
 						speed = self.data["gps_speed"] / self.data["count"]

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -1,6 +1,6 @@
 import time
-from overlay import Overlay, Colour
-import topics
+from CameraOverlay.overlay import Overlay, Colour
+import CameraOverlay.topics as topics
 
 
 class OverlayTopStrip(Overlay):
@@ -45,84 +45,56 @@ class OverlayTopStrip(Overlay):
 		self.base_canvas.draw_text("PMV:", (768, self.top_text_pos), colour=Colour.white)
 		self.base_canvas.draw_text("MS:", (1024, self.top_text_pos), colour=Colour.white)
 
-	def on_message(self, client, userdata, msg):
-		print(msg.topic + " " + str(msg.payload.decode("utf-8")))
+	def update_data_layer(self):
 		current_time = round(time.time(), 2)
-		if msg.topic == str(topics.PowerModel.recommended_sp):
-			parsed_data = self.parse_data(msg.payload)
-			self.data["rec_power"] = int(parsed_data["rec_power"])
-			self.data["zdist"] = int(parsed_data["zdist"])
-		elif msg.topic == str(topics.PowerModel.predicted_max_speed):
-			parsed_data = self.parse_data(msg.payload)
-			self.data["predicted_max_speed"] = float(parsed_data["predicted_max_speed"])
-		elif msg.topic == str(topics.PowerModel.plan_name):
-			parsed_data = self.parse_data(msg.payload)
-			self.data["plan_name"] = str(parsed_data["plan_name"])
-		elif msg.topic == str(topics.DAS.data):
-			parsed_data = self.parse_data(msg.payload)
-			print(str(parsed_data))
-			self.data["power"] += int(parsed_data["power"])
-			self.data["cadence"] += int(parsed_data["cadence"])
-			if int(parsed_data["gps"]) == 1:
-				self.data["gps_speed"] += float(parsed_data["gps_speed"])
-			self.data["reed_distance"] += float(parsed_data["reed_distance"])
-			self.data["count"] = self.data["count"] + 1
-			if self.prev_time == 0:
-				total_time = current_time - self.start_time
-			else:
-				total_time = current_time - self.prev_time
-			update_time = 1
-			if total_time >= update_time:
-				self.prev_time = current_time
-				# Create a transparent image to attach text
-				self.data_canvas.clear()
+		if self.prev_time == 0:
+			total_time = current_time - self.start_time
+		else:
+			total_time = current_time - self.prev_time
+		update_time = 1
+		if total_time >= update_time:
+			self.prev_time = current_time
+			# Create a transparent image to attach text
+			self.data_canvas.clear()
 
-				# Display elapsed time:
-				_, rem = divmod(time.time() - self.start_time, 3600)
-				minutes, seconds = divmod(rem, 60)
-				time_string = "{:0>2}:{:0>2}".format(int(minutes), int(seconds))
-				self.data_canvas.draw_text(time_string, (50, self.top_text_pos), colour=Colour.white)
+			# Display elapsed time:
+			_, rem = divmod(time.time() - self.start_time, 3600)
+			minutes, seconds = divmod(rem, 60)
+			time_string = "{:0>2}:{:0>2}".format(int(minutes), int(seconds))
+			self.data_canvas.draw_text(time_string, (50, self.top_text_pos), colour=Colour.white)
 
-				# Display power
-				if self.data["power"] != 0:
-					power = self.data["power"] / self.data["count"]
-					rec_power = self.data["rec_power"]
-					# Display recommended power
-					self.data_canvas.draw_text("{0}".format(round(rec_power, 0)), (600, self.top_text_pos), colour=Colour.white)
-					# Display power (no colour change)
-					self.data_canvas.draw_text("P: {0}".format(round(power, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y), size=self.bottom_text_size, colour=Colour.red)
+			# Display power
+			if self.data["power"] != 0:
+				power = self.data["power"] / self.data["count"]
+				rec_power = self.data["rec_power"]
+				# Display recommended power
+				self.data_canvas.draw_text("{0}".format(round(rec_power, 0)), (600, self.top_text_pos), colour=Colour.white)
+				# Display power (no colour change)
+				self.data_canvas.draw_text("P: {0}".format(round(power, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y), size=self.bottom_text_size, colour=Colour.red)
 
-				# Display speed
-				if int(parsed_data["gps"]) == 1:
-					if self.data["gps_speed"] != 0:
-						# Predicted max speed
-						pred_max_speed = self.data["predicted_max_speed"]
-						self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 1)), (890, self.top_text_pos), colour=Colour.white)
+			# Display speed
+			if self.data["gps"] == 1:
+				if self.data["gps_speed"] != 0:
+					# Predicted max speed
+					pred_max_speed = self.data["predicted_max_speed"]
+					self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 1)), (890, self.top_text_pos), colour=Colour.white)
 
-						# Actual speed (no colour change)
-						speed = self.data["gps_speed"] / self.data["count"]
-						self.data_canvas.draw_text("S: {0}".format(round(speed, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y - self.bottom_text_height), size=self.bottom_text_size, colour=Colour.red)
+					# Actual speed (no colour change)
+					speed = self.data["gps_speed"] / self.data["count"]
+					self.data_canvas.draw_text("S: {0}".format(round(speed, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y - self.bottom_text_height), size=self.bottom_text_size, colour=Colour.red)
 
-						# Actual max speed
-						self.data_canvas.draw_text("{0}".format(int(self.actual_max(speed))), (1120, self.top_text_pos), colour=Colour.white)
+					# Actual max speed
+					self.data_canvas.draw_text("{0}".format(int(self.actual_max(speed))), (1120, self.top_text_pos), colour=Colour.white)
 
-				# Display zone distance left (bugged)
-				if self.data["zdist"] != 0:
-					zdist_left = self.data["zdist"]
-					self.data_canvas.draw_text("{0}".format(int(zdist_left)), (360, self.top_text_pos), colour=Colour.white)
+			# Display zone distance left (bugged)
+			if self.data["zdist"] != 0:
+				zdist_left = self.data["zdist"]
+				self.data_canvas.draw_text("{0}".format(int(zdist_left)), (360, self.top_text_pos), colour=Colour.white)
 
-				# Display plan name and clear after 15 secs
-				if self.data["plan_name"] != '' and time.time() - self.start_time <= 15:
-					plan_name = self.data["plan_name"]
-					self.data_canvas.draw_text(plan_name, (0, self.height - 8), colour=Colour.red)
-
-				# Reset variables
-				self.data["power"] = 0
-				self.data["cadence"] = 0
-				self.data["gps_speed"] = 0
-				self.data["reed_distance"] = 0
-				self.data["count"] = 0
-
+			# Display plan name and clear after 15 secs
+			if self.data["plan_name"] != '' and time.time() - self.start_time <= 15:
+				plan_name = self.data["plan_name"]
+				self.data_canvas.draw_text(plan_name, (0, self.height - 8), colour=Colour.red)
 
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("Shows important statistics in a bar at the top of the screen")

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -65,7 +65,7 @@ class OverlayTopStrip(Overlay):
 
 			# Display power
 			if self.data["power"] != 0:
-				power = self.data["power"] / self.data["count"]
+				power = self.data["power"]
 				rec_power = self.data["rec_power"]
 				# Display recommended power
 				self.data_canvas.draw_text("{0}".format(round(rec_power, 0)), (600, self.top_text_pos), colour=Colour.white)
@@ -80,7 +80,7 @@ class OverlayTopStrip(Overlay):
 					self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 1)), (890, self.top_text_pos), colour=Colour.white)
 
 					# Actual speed (no colour change)
-					speed = self.data["gps_speed"] / self.data["count"]
+					speed = self.data["gps_speed"]
 					self.data_canvas.draw_text("S: {0}".format(round(speed, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y - self.bottom_text_height), size=self.bottom_text_size, colour=Colour.red)
 
 					# Actual max speed

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -1,6 +1,6 @@
 import time
-from CameraOverlay.overlay import Overlay, Colour
-import CameraOverlay.topics as topics
+from overlay import Overlay, Colour
+import topics as topics
 
 
 class OverlayTopStrip(Overlay):

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -1,6 +1,5 @@
 import time
 from overlay import Overlay, Colour
-import topics as topics
 
 
 class OverlayTopStrip(Overlay):

--- a/CameraOverlay/overlay_top_strip.py
+++ b/CameraOverlay/overlay_top_strip.py
@@ -46,55 +46,47 @@ class OverlayTopStrip(Overlay):
 		self.base_canvas.draw_text("MS:", (1024, self.top_text_pos), colour=Colour.white)
 
 	def update_data_layer(self):
-		current_time = round(time.time(), 2)
-		if self.prev_time == 0:
-			total_time = current_time - self.start_time
-		else:
-			total_time = current_time - self.prev_time
-		update_time = 1
-		if total_time >= update_time:
-			self.prev_time = current_time
-			# Create a transparent image to attach text
-			self.data_canvas.clear()
+		# Create a transparent image to attach text
+		self.data_canvas.clear()
 
-			# Display elapsed time:
-			_, rem = divmod(time.time() - self.start_time, 3600)
-			minutes, seconds = divmod(rem, 60)
-			time_string = "{:0>2}:{:0>2}".format(int(minutes), int(seconds))
-			self.data_canvas.draw_text(time_string, (50, self.top_text_pos), colour=Colour.white)
+		# Display elapsed time:
+		_, rem = divmod(time.time() - self.start_time, 3600)
+		minutes, seconds = divmod(rem, 60)
+		time_string = "{:0>2}:{:0>2}".format(int(minutes), int(seconds))
+		self.data_canvas.draw_text(time_string, (50, self.top_text_pos), colour=Colour.white)
 
-			# Display power
-			if self.data["power"] != 0:
-				power = self.data["power"]
-				rec_power = self.data["rec_power"]
-				# Display recommended power
-				self.data_canvas.draw_text("{0}".format(round(rec_power, 0)), (600, self.top_text_pos), colour=Colour.white)
-				# Display power (no colour change)
-				self.data_canvas.draw_text("P: {0}".format(round(power, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y), size=self.bottom_text_size, colour=Colour.red)
+		# Display power
+		if self.data["power"] != 0:
+			power = self.data["power"]
+			rec_power = self.data["rec_power"]
+			# Display recommended power
+			self.data_canvas.draw_text("{0}".format(round(rec_power, 0)), (600, self.top_text_pos), colour=Colour.white)
+			# Display power (no colour change)
+			self.data_canvas.draw_text("P: {0}".format(round(power, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y), size=self.bottom_text_size, colour=Colour.red)
 
-			# Display speed
-			if self.data["gps"] == 1:
-				if self.data["gps_speed"] != 0:
-					# Predicted max speed
-					pred_max_speed = self.data["predicted_max_speed"]
-					self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 1)), (890, self.top_text_pos), colour=Colour.white)
+		# Display speed
+		if self.data["gps"] == 1:
+			if self.data["gps_speed"] != 0:
+				# Predicted max speed
+				pred_max_speed = self.data["predicted_max_speed"]
+				self.data_canvas.draw_text("{0}".format(round(pred_max_speed, 1)), (890, self.top_text_pos), colour=Colour.white)
 
-					# Actual speed (no colour change)
-					speed = self.data["gps_speed"]
-					self.data_canvas.draw_text("S: {0}".format(round(speed, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y - self.bottom_text_height), size=self.bottom_text_size, colour=Colour.red)
+				# Actual speed (no colour change)
+				speed = self.data["gps_speed"]
+				self.data_canvas.draw_text("S: {0}".format(round(speed, 2)), (self.bottom_text_pos_x, self.bottom_text_pos_y - self.bottom_text_height), size=self.bottom_text_size, colour=Colour.red)
 
-					# Actual max speed
-					self.data_canvas.draw_text("{0}".format(int(self.actual_max(speed))), (1120, self.top_text_pos), colour=Colour.white)
+				# Actual max speed
+				self.data_canvas.draw_text("{0}".format(int(self.actual_max(speed))), (1120, self.top_text_pos), colour=Colour.white)
 
-			# Display zone distance left (bugged)
-			if self.data["zdist"] != 0:
-				zdist_left = self.data["zdist"]
-				self.data_canvas.draw_text("{0}".format(int(zdist_left)), (360, self.top_text_pos), colour=Colour.white)
+		# Display zone distance left (bugged)
+		if self.data["zdist"] != 0:
+			zdist_left = self.data["zdist"]
+			self.data_canvas.draw_text("{0}".format(int(zdist_left)), (360, self.top_text_pos), colour=Colour.white)
 
-			# Display plan name and clear after 15 secs
-			if self.data["plan_name"] != '' and time.time() - self.start_time <= 15:
-				plan_name = self.data["plan_name"]
-				self.data_canvas.draw_text(plan_name, (0, self.height - 8), colour=Colour.red)
+		# Display plan name and clear after 15 secs
+		if self.data["plan_name"] != '' and time.time() - self.start_time <= 15:
+			plan_name = self.data["plan_name"]
+			self.data_canvas.draw_text(plan_name, (0, self.height - 8), colour=Colour.red)
 
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("Shows important statistics in a bar at the top of the screen")


### PR DESCRIPTION
## Description

- All data-related stuff takes place in a single spot, `data.py`.
  - This includes storing most recent values, and parsing v2 and eventually v3 MQTT payloads into a standard format.
  - This used to be individually managed by each overlay implementation, causing lots of duplicated messy code.

As side affects of this PR,
- Power/speed values are no longer averaged between time the data overlay is updated.
  - Instead, just using most recent value.
  - I think we can do a better job of this in the future, implementing a "3 second power" field or the like. More importantly, this process should be independent of updating the data layer (which was not the case)
  - Do this in a future PR
- Fix predicted max power not displaying at all, due to a combination of incorrect MQTT topic names and payload parsing
- Overlay updates that don't rely on an incoming MQTT packet (i.e. elapsed time and hiding an expired message) now update without waiting for the next MQTT packet, as the overlays are now updated at a constant interval rather than when an MQTT packet is received.

## Screenshots

No visual changes. Example: `overlay_all_stats.py`

![Screenshot_20200423_115111](https://user-images.githubusercontent.com/17876556/80050394-ce1f5e80-8558-11ea-9526-74dec574e47c.png)

## Steps to Test

- Start your MQTT broker
- Start an overlay on a computer with a webcam with `python overlay_all_stats.py --host localhost` (for example)
- Test displaying data using `python mqtt_test.py` from the DAS repo
- Test power model data by running the BOOST orchestrator followed by `mqtt_test.py`
- Test displaying messages with `mosquitto_pub -t "/v3/camera/primary/message" -m "Test message"`
