### PR TITLE
Convert OverlayLayer to int when passed to picamera

### DIFF
--- a/overlay.py
+++ b/overlay.py
@@ -95,11 +95,11 @@ class Canvas():
 		dest = cv2.bitwise_and(dest, dest, mask=cv2.bitwise_not(mask))
 		return cv2.add(dest, img)
 
-	def update_pi_overlay(self, pi_camera, layer):
+	def update_pi_overlay(self, pi_camera, layer: OverlayLayer):
 		""" Adds the overlay to a PiCamera preview, and if the overlay was already added,
 		    removes the old instance. """
 		overlay = pi_camera.add_overlay(self.img, format="rgba", size=(self.width, self.height))
-		overlay.layer = layer
+		overlay.layer = layer.value
 		overlay.fullscreen = False
 		overlay.window = (*PI_WINDOW_TOP_LEFT, self.width, self.height)
 


### PR DESCRIPTION
## Description

Overlay layers are being passed to the `picamera` library as the `OverlayLayer` enum, rather than an integer, causing `picamera` to throw an exception and crash. This PR fixes the crash by converting the enum to an integer.

This was not picked up earlier as this code only runs on Raspberry Pis, and had not been tested on one.

## Screenshots

![Screenshot_20200523_092107](https://user-images.githubusercontent.com/17876556/82715551-f83e7a80-9cd6-11ea-88af-5f6c5d1430f1.png)

Works running on the Pi. Trippy, hey?

## Steps to Test

If you've got a Pi and camera, just try running any of the overlays.
