### PR TITLE
Add camera feed recording

### DIFF
--- a/overlay.py
+++ b/overlay.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import argparse
 from enum import Enum
 from json import dumps
-from os import path
+from os import mkdir, path
 from shutil import disk_usage
 import time
 
@@ -213,6 +213,9 @@ class Overlay(ABC):
 			with picamera. """
 		output_folder = path.dirname(path.realpath(__file__)) + "/recordings"
 		output_file_pattern = f"{output_folder}/rec_{{}}.h264"
+
+		if not path.exists(output_folder):
+			mkdir(output_folder)
 
 		video_number = 1
 		while path.exists(output_file_pattern.format(video_number)):

--- a/overlay.py
+++ b/overlay.py
@@ -249,7 +249,8 @@ class Overlay(ABC):
 				message["error"] = err
 		else:
 			message["status"] = "off"
-		message["diskSpaceRemaining"] = disk_usage(self.recording_output_file)
+		_, _, free_disk_space = disk_usage(__file__)
+		message["diskSpaceRemaining"] = free_disk_space
 
 		status_topic = f"{str(DAShboard.recording_status_root)}/{self.device}"
 		self.client.publish(status_topic, dumps(message), retain=True)

--- a/overlay.py
+++ b/overlay.py
@@ -147,8 +147,7 @@ class Overlay(ABC):
 		self.client.on_log = self.on_log
 
 		self.set_callback_for_topic_list(self.data.get_topics(), self.on_data_message)
-		self.client.message_callback_add(str(DAShboard.recording_start), self.start_recording)
-		self.client.message_callback_add(str(DAShboard.recording_stop), self.stop_recording)
+		self.client.message_callback_add(str(DAShboard.recording), self.on_recording_message)
 
 	def show_opencv_frame(self):
 		""" Creates the frame using the webcam and canvases, and displays result """
@@ -200,11 +199,11 @@ class Overlay(ABC):
 			if ON_PI:
 				self.pi_camera.stop_preview()
 
-	def start_recording(self, client, userdata, msg):
+	def start_recording(self):
 		print("started")
 		pass
 
-	def stop_recording(self, client, userdata, msg):
+	def stop_recording(self):
 		print("stoped")
 		pass
 
@@ -244,6 +243,12 @@ class Overlay(ABC):
 	def on_data_message(self, client, userdata, msg):
 		payload = msg.payload.decode("utf-8")
 		self.data.load_data(msg.topic, payload)
+
+	def on_recording_message(self, client, userdata, msg):
+		if DAShboard.recording_start.matches(msg):
+			self.start_recording()
+		elif DAShboard.recording_stop.matches(msg):
+			self.stop_recording()
 
 	@abstractmethod
 	def on_connect(self, client, userdata, flags, rc):

--- a/overlay.py
+++ b/overlay.py
@@ -157,7 +157,7 @@ class Overlay(ABC):
 		self.client.on_log = self.on_log
 
 		self.set_callback_for_topic_list(self.data.get_topics(), self.on_data_message)
-		self.client.message_callback_add(str(DAShboard.recording), self.on_recording_message)
+		self.set_callback_for_topic_list([str(DAShboard.recording)], self.on_recording_message)
 
 	def show_opencv_frame(self):
 		""" Creates the frame using the webcam and canvases, and displays result """

--- a/overlay.py
+++ b/overlay.py
@@ -229,7 +229,6 @@ class Overlay(ABC):
 			self.send_recording_status()
 		except Exception:
 			self.send_recording_error()
-			raise
 
 	def stop_recording(self):
 		""" Stops and saves any current recording at the location found in
@@ -244,7 +243,6 @@ class Overlay(ABC):
 			self.send_recording_status()
 		except Exception:
 			self.send_recording_error()
-			raise
 
 	def send_recording_status(self):
 		message = {}
@@ -258,7 +256,6 @@ class Overlay(ABC):
 
 			except Exception:
 				self.send_recording_error()
-				raise
 		else:
 			message["status"] = "off"
 		_, _, free_disk_space = disk_usage(__file__)
@@ -274,6 +271,7 @@ class Overlay(ABC):
 		}
 		status_topic = f"{str(DAShboard.recording_status_root)}/{self.device}"
 		self.client.publish(status_topic, dumps(message), retain=True)
+		print(format_exc)
 
 	def set_callback_for_topic_list(self, topics, callback):
 		""" Sets the on_message callback for every topic in topics to the

--- a/overlay.py
+++ b/overlay.py
@@ -233,6 +233,7 @@ class Overlay(ABC):
 		try:
 			self.pi_camera.start_recording(self.recording_output_file)
 			self.recording_start_time = time.time()
+			self.pi_camera.wait_recording(0.1)
 			self.send_recording_status()
 		except Exception:
 			self.send_recording_error()

--- a/overlay.py
+++ b/overlay.py
@@ -294,9 +294,9 @@ class Overlay(ABC):
 	def on_recording_message(self, client, userdata, msg):
 		if not ON_PI:
 			return
-		if DAShboard.recording_start.matches(msg):
+		if DAShboard.recording_start.matches(msg.topic):
 			self.start_recording()
-		elif DAShboard.recording_stop.matches(msg):
+		elif DAShboard.recording_stop.matches(msg.topic):
 			self.stop_recording()
 
 	@abstractmethod

--- a/overlay.py
+++ b/overlay.py
@@ -102,7 +102,7 @@ class Canvas():
 		""" Adds the overlay to a PiCamera preview, and if the overlay was already added,
 		    removes the old instance. """
 		overlay = pi_camera.add_overlay(self.img, format="rgba", size=(self.width, self.height))
-		overlay.layer = layer
+		overlay.layer = layer.value
 		overlay.fullscreen = False
 		overlay.window = (*PI_WINDOW_TOP_LEFT, self.width, self.height)
 

--- a/overlay.py
+++ b/overlay.py
@@ -212,6 +212,7 @@ class Overlay(ABC):
 			if ON_PI:
 				self.pi_camera.stop_preview()
 				self.stop_recording()
+				self.pi_camera.close()
 
 	def start_recording(self):
 		""" Starts an h264 recording with the first available name located in

--- a/overlay.py
+++ b/overlay.py
@@ -146,9 +146,9 @@ class Overlay(ABC):
 		self.client.on_disconnect = self.on_disconnect
 		self.client.on_log = self.on_log
 
-		self.client.message_callback_add(self.data.get_topics(), self.on_data_message)
-		self.client.message_callback_add(DAShboard.recording_start, self.start_recording)
-		self.client.message_callback_add(DAShboard.recording_stop, self.stop_recording)
+		self.set_callback_for_topic_list(self.data.get_topics(), self.on_data_message)
+		self.client.message_callback_add(str(DAShboard.recording_start), self.start_recording)
+		self.client.message_callback_add(str(DAShboard.recording_stop), self.stop_recording)
 
 	def show_opencv_frame(self):
 		""" Creates the frame using the webcam and canvases, and displays result """
@@ -201,10 +201,18 @@ class Overlay(ABC):
 				self.pi_camera.stop_preview()
 
 	def start_recording(self, client, userdata, msg):
+		print("started")
 		pass
 
 	def stop_recording(self, client, userdata, msg):
+		print("stoped")
 		pass
+
+	def set_callback_for_topic_list(self, topics, callback):
+		""" Sets the on_message callback for every topic in topics to the
+			provided callback """
+		for topic in topics:
+			self.client.message_callback_add(topic, callback)
 
 	def subscribe_to_topic_list(self, topics):
 		# https://pypi.org/project/paho-mqtt/#subscribe-unsubscribe
@@ -228,7 +236,7 @@ class Overlay(ABC):
 
 	def _on_connect(self, client, userdata, flags, rc):
 		self.subscribe_to_topic_list(self.data.get_topics())
-		self.client.subscribe(DAShboard.recording)
+		self.client.subscribe(str(DAShboard.recording))
 		self.on_connect(client, userdata, flags, rc)
 		if ON_PI:
 			self.base_canvas.update_pi_overlay(self.pi_camera, OverlayLayer.base)

--- a/overlay.py
+++ b/overlay.py
@@ -329,7 +329,7 @@ class Overlay(ABC):
 
 	def on_recording_message(self, client, userdata, msg):
 		if not ON_PI:
-			# Recording only works with picamera, for now
+			print("WARNING: Recording is not yet possible with OpenCV")
 			return
 		if DAShboard.recording_start.matches(msg.topic):
 			self.start_recording()

--- a/overlay.py
+++ b/overlay.py
@@ -282,7 +282,7 @@ class Overlay(ABC):
 		}
 		status_topic = f"{str(DAShboard.recording_status_root)}/{self.device}"
 		self.client.publish(status_topic, dumps(message), retain=True)
-		print(format_exc)
+		print(format_exc())
 
 	def set_callback_for_topic_list(self, topics, callback):
 		""" Sets the on_message callback for every topic in topics to the

--- a/recordings/.gitignore
+++ b/recordings/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/topics.py
+++ b/topics.py
@@ -41,7 +41,7 @@ class Camera(Topic):
 class DAShboard(Topic):
     """DAShboard MQTT Topics"""
     receive_message = '/v3/camera/primary/message'
-    recording = '/v3/camera/+' # Note wildcard does not include status topics
+    recording = '/v3/camera/recording/+' # Note wildcard does not include status topics
     recording_start = '/v3/camera/recording/start'
     recording_stop = '/v3/camera/recording/stop'
     recording_status_primary = '/v3/camera/recording/status/primary'

--- a/topics.py
+++ b/topics.py
@@ -44,8 +44,7 @@ class DAShboard(Topic):
     recording = '/v3/camera/recording/+' # Note wildcard does not include status topics
     recording_start = '/v3/camera/recording/start'
     recording_stop = '/v3/camera/recording/stop'
-    recording_status_primary = '/v3/camera/recording/status/primary'
-    recording_status_secondary = '/v3/camera/recording/status/secondary'
+    recording_status_root = '/v3/camera/recording/status'
 
 class SensorModules(Topic):
     """V3 Wireless sensor module topics"""

--- a/topics.py
+++ b/topics.py
@@ -41,6 +41,11 @@ class Camera(Topic):
 class DAShboard(Topic):
     """DAShboard MQTT Topics"""
     receive_message = '/v3/camera/primary/message'
+    recording = '/v3/camera/+' # Note wildcard does not include status topics
+    recording_start = '/v3/camera/recording/start'
+    recording_stop = '/v3/camera/recording/stop'
+    recording_status_primary = '/v3/camera/recording/status/primary'
+    recording_status_secondary = '/v3/camera/recording/status/secondary'
 
 class SensorModules(Topic):
     """V3 Wireless sensor module topics"""


### PR DESCRIPTION
## Description

With this change, the camera display Pis are able to start/stop recording via a message over MQTT.
The displays also reply with a recording status message, including status, disk space remaining, recording duration, or any errors that occurred. It also sends this data every 60 seconds. The idea is that this information may be presented on the DAShboard. The V3 MQTT spec has been updated, please take a look at it.

The remaining 9.3 GiB on the SD card I have seems to get a bit over 3.5 hours of h264 video recording (however, the video was mainly stationary - would that affect how long it lasts as it's perhaps easier to compress?)

## Screenshots

Here's a rather complicated screenshot. On the left is the RPi session. On the bottom left of that, you can see an explorer window with the recording output in the `recordings` folder. On the top right of the screen, you can see that I start the recording, and then stop it soon after. On the bottom right, you can see that the camera published its remaining space both when it received the `start` topic, 1720320 bytes or 1.6 MiB. I attempt to stop the recording not long later, but by this time all space has been used, and it publishes the traceback so we know what's up.

![Screenshot_20200523_214354](https://user-images.githubusercontent.com/17876556/82729871-90237f00-9d3e-11ea-9003-364532b80320.png)

Note that errors do not always get sent to MQTT as soon as they happen. Errors are checked for either every 60 seconds, or when you attempt to start/stop the recording.

## Steps to Test

Get a camera overlay running **on a Pi**. Publish to `/v3/camera/recording/start` and `/v3/camera/recording/stop`, ensure that the Pi correctly printed statuses to `/v3/camera/recording/status/<device>`, and ensure output is written to a file inside `recordings`. Try to break the error handling in whatever way you can.
