### PR TITLE
Add OpenCV backend for displaying static images

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -2,9 +2,11 @@ from .backend import Backend, PublishFunc
 from .backend_factory import BackendFactory
 from .picamera_backend import PiCameraBackend
 from .opencv_backend import OpenCVBackend
+from .opencv_static_image_backend import OpenCVStaticImageBackend
 __all__ = [
     "Backend", "PublishFunc",
     "BackendFactory",
     "PiCameraBackend",
     "OpenCVBackend",
+    "OpenCVStaticImageBackend",
 ]

--- a/backend/backend_factory.py
+++ b/backend/backend_factory.py
@@ -9,5 +9,7 @@ class BackendFactory:
             return backend.PiCameraBackend(width, height, publish_recording_status_func)
         elif backend_name == "opencv":
             return backend.OpenCVBackend(width, height, publish_recording_status_func)
+        elif backend_name == "opencv_static_image":
+            return backend.OpenCVStaticImageBackend(width, height, publish_recording_status_func)
         else:
             raise NotImplementedError(f"Unknown backend: {backend_name}")

--- a/backend/opencv_static_image_backend.py
+++ b/backend/opencv_static_image_backend.py
@@ -1,0 +1,52 @@
+import cv2
+import numpy as np
+
+from backend import Backend, PublishFunc
+from canvas import Canvas
+
+class OpenCVStaticImageBackend(Backend):
+    """ Displays a static, local image in place of a video feed.
+        Uses the OpenCV (`cv2`) library. """
+
+    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc):
+        super().__init__(width, height, publish_recording_status_func)
+
+        self.background = np.zeros((self.height, self.width, 4), np.uint8)
+
+        framerate = 60
+        # Time between video frames when running on OpenCV, in milliseconds
+        self.frametime = int(1000 / framerate)
+
+        self.base_canvas = Canvas(self.width, self.height)
+        self.data_canvas = Canvas(self.width, self.height)
+        self.message_canvas = Canvas(self.width, self.height)
+
+    def start_video(self) -> None:
+        # Nothing to do
+        pass
+
+    def set_background(self, image_path: str) -> None:
+        background_original = cv2.imread(cv2.samples.findFile(image_path))
+        self.background = cv2.resize(background_original, (self.width, self.height))
+
+    def on_base_canvas_updated(self, base_canvas: Canvas) -> None:
+        self.base_canvas = base_canvas
+
+    def on_canvases_updated(self, data_canvas: Canvas, message_canvas: Canvas) -> None:
+        self.data_canvas = data_canvas
+        self.message_canvas = message_canvas
+
+    def _on_loop(self) -> None:
+        """ This function uses the cached overlays, as OpenCV needs us to
+            manually add it to each frame. """
+        frame = self.background
+
+        frame = self.base_canvas.copy_to(frame)
+        frame = self.data_canvas.copy_to(frame)
+        frame = self.message_canvas.copy_to(frame)
+
+        cv2.imshow('frame', frame)
+        cv2.waitKey(self.frametime)
+
+    def stop_video(self) -> None:
+        cv2.destroyAllWindows()

--- a/overlay_all_stats.py
+++ b/overlay_all_stats.py
@@ -4,8 +4,8 @@ from canvas import Colour
 
 class OverlayAllStats(Overlay):
 
-	def __init__(self, bike=None):
-		super(OverlayAllStats, self).__init__(bike)
+	def __init__(self, bike=None, bg=None):
+		super(OverlayAllStats, self).__init__(bike, bg=bg)
 		self.text_height = 50
 		self.speed_height = 70
 		self.message_received_time = 0
@@ -99,5 +99,5 @@ class OverlayAllStats(Overlay):
 
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("Overlay displaying all (or just many) statistics")
-	my_overlay = OverlayAllStats(args.bike)
+	my_overlay = OverlayAllStats(args.bike, args.bg)
 	my_overlay.connect(ip=args.host)

--- a/overlay_blank.py
+++ b/overlay_blank.py
@@ -3,8 +3,8 @@ from canvas import Colour
 
 class OverlayBlank(Overlay):
 
-	def __init__(self, bike=None):
-		super(OverlayBlank, self).__init__(bike)
+	def __init__(self, bike=None, bg=None):
+		super(OverlayBlank, self).__init__(bike, bg=bg)
 
 	def on_connect(self, client, userdata, flags, rc):
 		print('Connected with rc: {}'.format(rc))
@@ -19,5 +19,5 @@ class OverlayBlank(Overlay):
 
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("An empty, example overlay")
-	my_overlay = OverlayBlank(args.bike)
+	my_overlay = OverlayBlank(args.bike, args.bg)
 	my_overlay.connect(ip=args.host)

--- a/overlay_top_strip.py
+++ b/overlay_top_strip.py
@@ -5,8 +5,8 @@ from canvas import Colour
 
 class OverlayTopStrip(Overlay):
 
-	def __init__(self, bike=None):
-		super(OverlayTopStrip, self).__init__(bike)
+	def __init__(self, bike=None, bg=None):
+		super(OverlayTopStrip, self).__init__(bike, bg=bg)
 
 		self.start_time = round(time.time(), 2)
 
@@ -82,5 +82,5 @@ class OverlayTopStrip(Overlay):
 
 if __name__ == '__main__':
 	args = Overlay.get_overlay_args("Shows important statistics in a bar at the top of the screen")
-	my_overlay = OverlayTopStrip(args.bike)
+	my_overlay = OverlayTopStrip(args.bike, args.bg)
 	my_overlay.connect(ip=args.host)


### PR DESCRIPTION
## Description

This PR allows a developer to replace the webcam/picamera video feed with a static image from a local file. This is useful for two reasons:
- It lets us develop overlays taking in mind what they will look like when on the track, to ensure all text is readable.
- It lets us test `raspicam` on computers without webcams.

## Screenshots

![image](https://user-images.githubusercontent.com/17876556/84329727-dabf4b00-abc8-11ea-96e2-64d1cffcb74c.png)

## Steps to Test

Download the following screenshot I took from an old recording on the drive:

![Screenshot_20200610_225701](https://user-images.githubusercontent.com/17876556/84329936-5faa6480-abc9-11ea-8592-b657763c4145.png)

(please excuse the youtube video controls... I couldn't be bothered to download the 1 GB video just for a screenshot without that in the way)

Then, run any overlay with the argument `--bg <path to image>`. The path may be absolute, or relative to the root `raspicam` folder.