### PR TITLE
Change path passed to disk_usage to be the file's parent directory

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -179,7 +179,7 @@ class Backend(ABC):
         self.prev_recording_status_time = time()
 
     def send_recording_error(self) -> None:
-        """ Send the most recent exception to the recording status MQTT topic """
+        """ Send the most recent exception to the recording status MQTT topic. """
 
         _, _, free_disk_space = disk_usage(Path(__file__).parent)
         message = {

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -172,7 +172,7 @@ class Backend(ABC):
                 return
         else:
             message["status"] = "off"
-        _, _, free_disk_space = disk_usage(Path(__file__).parents[0])
+        _, _, free_disk_space = disk_usage(Path(__file__).parent)
         message["diskSpaceRemaining"] = free_disk_space
 
         self.publish_recording_status_func(dumps(message))
@@ -181,7 +181,7 @@ class Backend(ABC):
     def send_recording_error(self) -> None:
         """ Send the most recent exception to the recording status MQTT topic """
 
-        _, _, free_disk_space = disk_usage(Path(__file__).parents[0])
+        _, _, free_disk_space = disk_usage(Path(__file__).parent)
         message = {
             "status": "error",
             "error": format_exc(),

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -172,7 +172,7 @@ class Backend(ABC):
                 return
         else:
             message["status"] = "off"
-        _, _, free_disk_space = disk_usage(__file__)
+        _, _, free_disk_space = disk_usage(Path(__file__).parents[0])
         message["diskSpaceRemaining"] = free_disk_space
 
         self.publish_recording_status_func(dumps(message))
@@ -181,7 +181,7 @@ class Backend(ABC):
     def send_recording_error(self) -> None:
         """ Send the most recent exception to the recording status MQTT topic """
 
-        _, _, free_disk_space = disk_usage(__file__)
+        _, _, free_disk_space = disk_usage(Path(__file__).parents[0])
         message = {
             "status": "error",
             "error": format_exc(),


### PR DESCRIPTION
## Description

In `backend.py`, `disk_usage` ([docs](https://docs.python.org/3/library/shutil.html#shutil.disk_usage)) is used to find the space left on the disk. Currently, `__file__` (the path to the executing file) is passed to it but this is only introduced in python 3.8 while the install instructions state that python 3.7.7 is to be used.

Using `__file__` in a `NotADirectory` error for me, whereas using the parent directory of `__file__` works as expected.

## Steps to Test

1. Install `raspicam`

2. Run `python overlay_new.py`
