### PR TITLE
Make raspicam publish retained message to know when the video feed is running

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -28,7 +28,7 @@ class Backend(ABC):
         self.recording_output_file = None
         self.recording_start_time = None
 
-        # time that we last called self.send_recording_status
+        # Time that we last called self.send_recording_status
         self.prev_recording_status_time = 0
         # Time between recording statuses, in seconds
         self.recording_status_interval = 60
@@ -40,7 +40,7 @@ class Backend(ABC):
 
     @abstractmethod
     def _is_camera_on(self) -> bool:
-        """ Checks if the camera / video feed / display is on
+        """ Check if the camera / video feed / display is on.
 
         Returns:
             bool: True if is on, False otherwise

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -225,3 +225,4 @@ class Backend(ABC):
     def __exit__(self, exc_type, exc_value, traceback):
         """ Ran when exiting a `with` block. """
         self.stop_video()
+        self.send_camera_is_online()

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -33,6 +33,11 @@ class Backend(ABC):
         # Time between recording statuses, in seconds
         self.recording_status_interval = 60
 
+        # time that we last called self.send_camera_is_online
+        self.prev_camera_is_online_time = 0
+        # Time between recording statuses, in seconds
+        self.camera_is_online_interval = 60
+
     @abstractmethod
     def _is_camera_on(self) -> bool:
         """ Checks if the camera / video feed / display is on
@@ -89,12 +94,23 @@ class Backend(ABC):
         if time() > self.prev_recording_status_time + self.recording_status_interval:
             self.send_recording_status()
 
+        if time() > self.prev_camera_is_online_time + self.camera_is_online_interval:
+            self.send_camera_is_online()
+
     @abstractmethod
     def _on_loop(self) -> None:
-        """ Implemented by overlays to perform any neccessary operations that
+        """ Implemented by overlays to perform any necessary operations that
             should be performed on a regular period. This may involve updating
             the display, which may be blocking. Should not be called outside
             of the Backend class. """
+
+    def send_camera_is_online(self) -> None:
+        """ Publish the camera's status to the camera's online topic
+        """
+        self.publish_camera_is_online_func(dumps({
+            "online": self._is_camera_on()
+        }))
+        self.prev_camera_is_online_time = time()
 
     @abstractmethod
     def stop_video(self) -> None:

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -33,7 +33,7 @@ class Backend(ABC):
         # Time between recording statuses, in seconds
         self.recording_status_interval = 60
 
-        # time that we last called self.send_camera_is_online
+        # Time that we last called self.send_camera_is_online
         self.prev_camera_is_online_time = 0
         # Time between recording statuses, in seconds
         self.camera_is_online_interval = 60

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -105,8 +105,7 @@ class Backend(ABC):
             of the Backend class. """
 
     def send_camera_is_online(self) -> None:
-        """ Publish the camera's status to the camera's online topic
-        """
+        """ Publish the camera's status to the camera's online topic. """
         self.publish_camera_is_online_func(dumps({
             "online": self._is_camera_on()
         }))

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -103,13 +103,6 @@ class Backend(ABC):
             the display, which may be blocking. Should not be called outside
             of the Backend class. """
 
-    def send_camera_is_online(self) -> None:
-        """ Publish the camera's status to the camera's online topic. """
-        self.publish_camera_is_online_func(dumps({
-            "online": self._is_camera_on()
-        }))
-        self.prev_camera_is_online_time = time()
-
     @abstractmethod
     def stop_video(self) -> None:
         """ Stop displaying the video feed and releases any resources
@@ -213,6 +206,13 @@ class Backend(ABC):
         }
         self.publish_recording_status_func(dumps(message))
         print(format_exc())
+
+    def send_camera_is_online(self) -> None:
+        """ Publish the camera's status to the camera's online topic. """
+        self.publish_camera_is_online_func(dumps({
+            "online": self._is_camera_on()
+        }))
+        self.prev_camera_is_online_time = time()
 
     def __enter__(self):
         """ Ran when Python's `with ...` syntax is used on an instance of this

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -17,10 +17,11 @@ class Backend(ABC):
         Handle combining the video feed with overlays and displaying, and
         recording the video feed to a file. """
 
-    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, exception_handler: PublishFunc):
+    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_camera_is_online_func: PublishFunc, exception_handler: PublishFunc):
         self.width = width
         self.height = height
         self.publish_recording_status_func = publish_recording_status_func
+        self.publish_camera_is_online_func = publish_camera_is_online_func
         self.exception_handler = exception_handler
 
         self.recording = False
@@ -31,6 +32,15 @@ class Backend(ABC):
         self.prev_recording_status_time = 0
         # Time between recording statuses, in seconds
         self.recording_status_interval = 60
+
+    @abstractmethod
+    def _is_camera_on(self) -> bool:
+        """ Checks if the camera / video feed / display is on
+
+        Returns:
+            bool: True if is on, False otherwise
+        """
+        pass
 
     @abstractmethod
     def start_video(self) -> None:

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -45,7 +45,6 @@ class Backend(ABC):
         Returns:
             bool: True if is on, False otherwise
         """
-        pass
 
     @abstractmethod
     def start_video(self) -> None:

--- a/backend/backend_factory.py
+++ b/backend/backend_factory.py
@@ -3,13 +3,13 @@ import backend
 class BackendFactory:
 
     @staticmethod
-    def create(backend_name: str, width: int, height: int, publish_recording_status_func, exception_handler) -> backend.Backend:
+    def create(backend_name: str, width: int, height: int, publish_recording_status_func, publish_camera_is_online_func,  exception_handler) -> backend.Backend:
         backend_name = backend_name.lower()
         if backend_name == "picamera":
-            return backend.PiCameraBackend(width, height, publish_recording_status_func, exception_handler)
+            return backend.PiCameraBackend(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
         elif backend_name == "opencv":
-            return backend.OpenCVBackend(width, height, publish_recording_status_func, exception_handler)
+            return backend.OpenCVBackend(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
         elif backend_name == "opencv_static_image":
-            return backend.OpenCVStaticImageBackend(width, height, publish_recording_status_func, exception_handler)
+            return backend.OpenCVStaticImageBackend(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
         else:
             raise NotImplementedError(f"Unknown backend: {backend_name}")

--- a/backend/backend_factory.py
+++ b/backend/backend_factory.py
@@ -3,13 +3,13 @@ import backend
 class BackendFactory:
 
     @staticmethod
-    def create(backend_name: str, width: int, height: int, publish_recording_status_func, publish_camera_is_online_func,  exception_handler) -> backend.Backend:
+    def create(backend_name: str, width: int, height: int, publish_recording_status_func, publish_video_status_func,  exception_handler) -> backend.Backend:
         backend_name = backend_name.lower()
         if backend_name == "picamera":
-            return backend.PiCameraBackend(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
+            return backend.PiCameraBackend(width, height, publish_recording_status_func, publish_video_status_func, exception_handler)
         elif backend_name == "opencv":
-            return backend.OpenCVBackend(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
+            return backend.OpenCVBackend(width, height, publish_recording_status_func, publish_video_status_func, exception_handler)
         elif backend_name == "opencv_static_image":
-            return backend.OpenCVStaticImageBackend(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
+            return backend.OpenCVStaticImageBackend(width, height, publish_recording_status_func, publish_video_status_func, exception_handler)
         else:
             raise NotImplementedError(f"Unknown backend: {backend_name}")

--- a/backend/opencv_backend.py
+++ b/backend/opencv_backend.py
@@ -1,7 +1,7 @@
 import cv2
-
 from backend import Backend, PublishFunc
 from canvas import Canvas
+
 
 class OpenCVBackend(Backend):
     """ Gets and displays video using the OpenCV (`cv2`) library.
@@ -9,8 +9,8 @@ class OpenCVBackend(Backend):
         This is intended for use with laptops with webcams, not on the
         Raspberry Pi. """
 
-    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_camera_is_online_func: PublishFunc, exception_handler: PublishFunc):
-        super().__init__(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
+    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_video_status_func: PublishFunc, exception_handler: PublishFunc):
+        super().__init__(width, height, publish_recording_status_func, publish_video_status_func, exception_handler)
         self.webcam = None
 
         framerate = 60
@@ -26,7 +26,7 @@ class OpenCVBackend(Backend):
         default_camera_index = 0
         self.webcam = cv2.VideoCapture(default_camera_index)
 
-    def _is_camera_on(self):
+    def _is_video_on(self):
         if self.webcam is None:
             return False
         return self.webcam.isOpened()

--- a/backend/opencv_backend.py
+++ b/backend/opencv_backend.py
@@ -9,8 +9,8 @@ class OpenCVBackend(Backend):
         This is intended for use with laptops with webcams, not on the
         Raspberry Pi. """
 
-    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, exception_handler: PublishFunc):
-        super().__init__(width, height, publish_recording_status_func, exception_handler)
+    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_camera_is_online_func: PublishFunc, exception_handler: PublishFunc):
+        super().__init__(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
         self.webcam = None
 
         framerate = 60
@@ -25,6 +25,11 @@ class OpenCVBackend(Backend):
         # Uses whatever OpenCV determines to be the "default camera"
         default_camera_index = 0
         self.webcam = cv2.VideoCapture(default_camera_index)
+
+    def _is_camera_on(self):
+        if self.webcam is None:
+            return False
+        return self.webcam.isOpened()
 
     def _on_base_canvas_updated(self, base_canvas: Canvas) -> None:
         self.base_canvas = base_canvas

--- a/backend/opencv_static_image_backend.py
+++ b/backend/opencv_static_image_backend.py
@@ -8,8 +8,8 @@ class OpenCVStaticImageBackend(Backend):
     """ Displays a static, local image in place of a video feed.
         Uses the OpenCV (`cv2`) library. """
 
-    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, exception_handler: PublishFunc):
-        super().__init__(width, height, publish_recording_status_func, exception_handler)
+    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_camera_is_online_func: PublishFunc, exception_handler: PublishFunc):
+        super().__init__(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
         self.background = np.zeros((self.height, self.width, 4), np.uint8)
 
         framerate = 60
@@ -19,6 +19,10 @@ class OpenCVStaticImageBackend(Backend):
         self.base_canvas = Canvas(self.width, self.height)
         self.data_canvas = Canvas(self.width, self.height)
         self.message_canvas = Canvas(self.width, self.height)
+
+    def _is_camera_on(self):
+        # Static image always has something displayed
+        return True
 
     def start_video(self) -> None:
         # Nothing to do

--- a/backend/opencv_static_image_backend.py
+++ b/backend/opencv_static_image_backend.py
@@ -8,8 +8,8 @@ class OpenCVStaticImageBackend(Backend):
     """ Displays a static, local image in place of a video feed.
         Uses the OpenCV (`cv2`) library. """
 
-    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_camera_is_online_func: PublishFunc, exception_handler: PublishFunc):
-        super().__init__(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
+    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_video_status_func: PublishFunc, exception_handler: PublishFunc):
+        super().__init__(width, height, publish_recording_status_func, publish_video_status_func, exception_handler)
         self.background = np.zeros((self.height, self.width, 4), np.uint8)
 
         framerate = 60
@@ -20,7 +20,7 @@ class OpenCVStaticImageBackend(Backend):
         self.data_canvas = Canvas(self.width, self.height)
         self.message_canvas = Canvas(self.width, self.height)
 
-    def _is_camera_on(self):
+    def _is_video_on(self):
         # Static image always has something displayed
         return True
 

--- a/backend/picamera_backend.py
+++ b/backend/picamera_backend.py
@@ -30,8 +30,8 @@ class PiCameraBackend(Backend):
         This backend will only work when the `picamera` library is available,
         i.e. when running on a Raspberry Pi. """
 
-    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_camera_is_online_func: PublishFunc, exception_handler: PublishFunc):
-        super().__init__(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
+    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_video_status_func: PublishFunc, exception_handler: PublishFunc):
+        super().__init__(width, height, publish_recording_status_func, publish_video_status_func, exception_handler)
 
         if not ON_PI:
             raise RuntimeError("`picamera` library unavailable - please run on Pi or install library")
@@ -40,7 +40,7 @@ class PiCameraBackend(Backend):
 
         self.prev_overlays: Dict[PiCameraOverlayLayer, self.pi_camera.PiOverlayRenderer] = {}
 
-    def _is_camera_on(self):
+    def _is_video_on(self):
         return self.pi_camera.previewing
 
     def start_video(self) -> None:

--- a/backend/picamera_backend.py
+++ b/backend/picamera_backend.py
@@ -30,18 +30,21 @@ class PiCameraBackend(Backend):
         This backend will only work when the `picamera` library is available,
         i.e. when running on a Raspberry Pi. """
 
-    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, exception_handler: PublishFunc):
-        super().__init__(width, height, publish_recording_status_func, exception_handler)
+    def __init__(self, width: int, height: int, publish_recording_status_func: PublishFunc, publish_camera_is_online_func: PublishFunc, exception_handler: PublishFunc):
+        super().__init__(width, height, publish_recording_status_func, publish_camera_is_online_func, exception_handler)
 
         if not ON_PI:
             raise RuntimeError("`picamera` library unavailable - please run on Pi or install library")
-        
+
         self.pi_camera = PiCamera(resolution=(self.width, self.height))
 
         self.prev_overlays: Dict[PiCameraOverlayLayer, self.pi_camera.PiOverlayRenderer] = {}
 
+    def _is_camera_on(self):
+        return ON_PI
+
     def start_video(self) -> None:
-        # Start displaying video feed. Non blocking, but runs forever in seperate thread.
+        # Start displaying video feed. Non blocking, but runs forever in separate thread.
         self.pi_camera.start_preview(fullscreen=False, window=(*PI_WINDOW_TOP_LEFT, self.width, self.height))
 
     def update_picamera_overlay(self, canvas: Canvas, layer: PiCameraOverlayLayer) -> None:

--- a/backend/picamera_backend.py
+++ b/backend/picamera_backend.py
@@ -41,7 +41,7 @@ class PiCameraBackend(Backend):
         self.prev_overlays: Dict[PiCameraOverlayLayer, self.pi_camera.PiOverlayRenderer] = {}
 
     def _is_camera_on(self):
-        return ON_PI
+        return self.pi_camera.previewing
 
     def start_video(self) -> None:
         # Start displaying video feed. Non blocking, but runs forever in separate thread.

--- a/overlay.py
+++ b/overlay.py
@@ -10,7 +10,7 @@ from config import read_configs
 from canvas import Canvas
 from data import DataFactory, Data
 from platform import machine
-from topics import DAShboard
+from topics import DAShboard, Camera
 from camera_error_handler import CameraErrorHandler
 
 DEFAULT_BIKE = "V2"
@@ -52,7 +52,7 @@ class Overlay(ABC):
 
 		self.set_callback_for_topic_list(self.data.get_topics(), self.on_data_message)
 		self.set_callback_for_topic_list([str(DAShboard.recording)], self.on_recording_message)
-		self.exception_handler = CameraErrorHandler(self.client, self.device, self.backend_name, 
+		self.exception_handler = CameraErrorHandler(self.client, self.device, self.backend_name,
 													self.bg_path, configs)
 
 		self.start_time = time.time()
@@ -62,12 +62,24 @@ class Overlay(ABC):
 		status_topic = f"{str(DAShboard.recording_status_root)}/{self.device}"
 		self.client.publish(status_topic, message, retain=True)
 
+	def publish_camera_is_online(self, message: str) -> None:
+		""" Send a message on the current device's online topic
+		"""
+		status_topic = f"{str(Camera.online_root)}/{self.device}"
+		self.client.publish(status_topic, message, retain=True)
+
 	def connect(self, ip="192.168.100.100", port=1883):
 		self.client.connect_async(ip, port, 60)
 
 		with self.exception_handler:
-			with BackendFactory.create(self.backend_name, self.width, self.height, self.publish_recording_status,
-										self.exception_handler) as self.backend:
+			with BackendFactory.create(
+				self.backend_name,
+				self.width,
+				self.height,
+				self.publish_recording_status,
+				self.publish_camera_is_online,
+				self.exception_handler
+			) as self.backend:
 
 				if self.backend_name == "opencv_static_image":
 					self.backend.set_background(self.bg_path)

--- a/overlay.py
+++ b/overlay.py
@@ -11,7 +11,7 @@ from camera_error_handler import CameraErrorHandler
 from canvas import Canvas
 from config import read_configs
 from data import Data, DataFactory
-from topics import Camera, DAShboard
+from topics import DAShboard
 
 DEFAULT_BIKE = "V2"
 
@@ -52,7 +52,7 @@ class Overlay(ABC):
 		self.client.on_log = self.on_log
 
 		# Set the camera status to offline if connection breaks
-		is_online_topic = f"{str(Camera.online_root)}/{self.device}";
+		is_online_topic = f"{str(DAShboard.video_feed_status_root)}/{self.device}";
 		self.client.will_set(
 			is_online_topic,
 			dumps({ "online": False }),
@@ -74,7 +74,7 @@ class Overlay(ABC):
 
 	def publish_camera_is_online(self, message: str) -> None:
 		""" Send a message on the current device's online topic. """
-		online_status_topic = f"{str(Camera.online_root)}/{self.device}"
+		online_status_topic = f"{str(DAShboard.video_feed_status_root)}/{self.device}"
 		self.client.publish(online_status_topic, message, retain=True)
 
 	def connect(self, ip="192.168.100.100", port=1883):

--- a/overlay.py
+++ b/overlay.py
@@ -73,8 +73,7 @@ class Overlay(ABC):
 		self.client.publish(status_topic, message, retain=True)
 
 	def publish_camera_is_online(self, message: str) -> None:
-		""" Send a message on the current device's online topic
-		"""
+		""" Send a message on the current device's online topic. """
 		status_topic = f"{str(Camera.online_root)}/{self.device}"
 		self.client.publish(status_topic, message, retain=True)
 

--- a/overlay.py
+++ b/overlay.py
@@ -72,7 +72,7 @@ class Overlay(ABC):
 		status_topic = f"{str(DAShboard.recording_status_root)}/{self.device}"
 		self.client.publish(status_topic, message, retain=True)
 
-	def publish_camera_is_online(self, message: str) -> None:
+	def publish_video_status(self, message: str) -> None:
 		""" Send a message on the current device's online topic. """
 		online_status_topic = f"{str(DAShboard.video_feed_status_root)}/{self.device}"
 		self.client.publish(online_status_topic, message, retain=True)
@@ -86,7 +86,7 @@ class Overlay(ABC):
 				self.width,
 				self.height,
 				self.publish_recording_status,
-				self.publish_camera_is_online,
+				self.publish_video_status,
 				self.exception_handler
 			) as self.backend:
 

--- a/overlay.py
+++ b/overlay.py
@@ -10,6 +10,7 @@ from config import read_configs
 from canvas import Canvas
 from data import DataFactory, Data
 from platform import machine
+from json import dumps
 from topics import DAShboard, Camera
 from camera_error_handler import CameraErrorHandler
 
@@ -45,10 +46,17 @@ class Overlay(ABC):
 		self.data = DataFactory.create(bike_version)
 		self.device = configs["device"]
 
+		# mqtt client options
 		self.client = mqtt.Client()
 		self.client.on_connect = self._on_connect
 		self.client.on_disconnect = self.on_disconnect
 		self.client.on_log = self.on_log
+		self.client.will_set(
+			f"{str(Camera.online_root)}/{self.device}",
+			dumps({ "online": False }),
+			1,
+			True
+		) # set the camera status to offline if connection breaks
 
 		self.set_callback_for_topic_list(self.data.get_topics(), self.on_data_message)
 		self.set_callback_for_topic_list([str(DAShboard.recording)], self.on_recording_message)

--- a/overlay.py
+++ b/overlay.py
@@ -74,8 +74,8 @@ class Overlay(ABC):
 
 	def publish_camera_is_online(self, message: str) -> None:
 		""" Send a message on the current device's online topic. """
-		status_topic = f"{str(Camera.online_root)}/{self.device}"
-		self.client.publish(status_topic, message, retain=True)
+		online_status_topic = f"{str(Camera.online_root)}/{self.device}"
+		self.client.publish(online_status_topic, message, retain=True)
 
 	def connect(self, ip="192.168.100.100", port=1883):
 		self.client.connect_async(ip, port, 60)

--- a/topics.py
+++ b/topics.py
@@ -38,6 +38,7 @@ class Camera(Topic):
     set_overlay = 'camera/set_overlay'
     push_overlays = 'camera/push_overlays'
     errors = '/v3/camera/errors'
+    online_root = '/v3/camera/online'
 
 class DAShboard(Topic):
     """DAShboard MQTT Topics"""

--- a/topics.py
+++ b/topics.py
@@ -40,7 +40,6 @@ class Camera(Topic):
     set_overlay = 'camera/set_overlay'
     push_overlays = 'camera/push_overlays'
     errors = '/v3/camera/errors'
-    online_root = '/v3/camera/video-feed/status'
 
 class DAShboard(Topic):
     """DAShboard MQTT Topics"""
@@ -49,6 +48,8 @@ class DAShboard(Topic):
     recording_start = '/v3/camera/recording/start'
     recording_stop = '/v3/camera/recording/stop'
     recording_status_root = '/v3/camera/recording/status'
+
+    video_feed_status_root = '/v3/camera/video-feed/status'
 
 class SensorModules(Topic):
     """V3 Wireless sensor module topics"""

--- a/topics.py
+++ b/topics.py
@@ -1,6 +1,8 @@
 """MQTT Topics for Camera System"""
 from enum import Enum, unique
+
 from paho.mqtt.client import topic_matches_sub
+
 
 @unique
 class Topic(Enum):
@@ -38,7 +40,7 @@ class Camera(Topic):
     set_overlay = 'camera/set_overlay'
     push_overlays = 'camera/push_overlays'
     errors = '/v3/camera/errors'
-    online_root = '/v3/camera/online'
+    online_root = '/v3/camera/video-feed/status'
 
 class DAShboard(Topic):
     """DAShboard MQTT Topics"""


### PR DESCRIPTION
## Description

`raspicam` will publish to the topic ~'/v3/camera/online/<primary/secondary>'~ `/v3/camera/video-feed/online/<primary/secondary>` when it is turned on and off as specified in the V3 MQTT Topics Notion page.

Currently, the payload only contains a boolean representing on/off.

I have hardcoded in the method used to publish to the camera as well as the periodic update variables `self.prev_camera_is_online_time` and `self.camera_is_online_interval` (pretty much the same stuff as for recording status). 
Should I modularise the code to accept an arbitrary number of `PublishFunc`? I think for 2 methods it's fine considering it may (?) be unlikely for us to extend the functionality in this area, thoughts?

## Screenshots

![image](https://user-images.githubusercontent.com/50545432/89729410-d3a5a380-da78-11ea-8746-6372d4fa0f2e.png)

Actions corresponding to each line
1. Retained payload
2. Camera turned on
3. LWT payload due to `KeyboardInterrupt`
4. Camera turned off

## Steps to Test

1. Install `raspicam`

2. Start a `mosquitto` broker

3. Run `overlay_new.py` (or any other overlay)
