### PR TITLE
Display error message on overlay when DAS is disconnected

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -2,6 +2,7 @@ from .component import Component
 from .data_field import DataField, SpeedField
 from .centre_power import CentrePower
 from .message import Message
+from .das_disconnect_message import DASDisconnectMessage
 
 __all__ = [
     "Component",
@@ -9,4 +10,5 @@ __all__ = [
     "SpeedField",
     "CentrePower",
     "Message",
+    "DASDisconnectMessage"
 ]

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -1,7 +1,7 @@
 from .component import Component
 from .data_field import DataField, SpeedField
 from .centre_power import CentrePower
-from .message import Message
+from .dashboard_message import DAShboardMessage
 from .das_disconnect_message import DASDisconnectMessage
 
 __all__ = [
@@ -9,6 +9,6 @@ __all__ = [
     "DataField",
     "SpeedField",
     "CentrePower",
-    "Message",
+    "DAShboardMessage",
     "DASDisconnectMessage",
 ]

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -1,6 +1,7 @@
 from .component import Component
 from .data_field import DataField, SpeedField
 from .centre_power import CentrePower
+from .message import Message
 from .dashboard_message import DAShboardMessage
 from .das_disconnect_message import DASDisconnectMessage
 

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "DataField",
     "SpeedField",
     "CentrePower",
+    "Message",
     "DAShboardMessage",
     "DASDisconnectMessage",
 ]

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -10,5 +10,5 @@ __all__ = [
     "SpeedField",
     "CentrePower",
     "Message",
-    "DASDisconnectMessage"
+    "DASDisconnectMessage",
 ]

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -6,5 +6,9 @@ class DASDisconnectMessage(Message):
     text_colour = Colour.red
 
     def draw_data(self, canvas: Canvas):
-        disconnected_message = "Message: DAS is disconnected. Connect to a broker."
-        self.display_message(canvas, disconnected_message, DASDisconnectMessage.text_colour)
+        disconnected_message = (
+            "Message: DAS is disconnected. Connect to a broker."
+        )
+        self.display_message(
+            canvas, disconnected_message, DASDisconnectMessage.text_colour
+        )

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -4,25 +4,31 @@ from data import Data
 
 
 class DASDisconnectMessage(Message):
-    """Class displays error message on overlay when DAS is not
-    connected, or overlay is not connected to an MQTT broker.
+    """Class displays error message on overlay when DAS is not connected, or
+    overlay is not connected to an MQTT broker.
 
     Attributes:
         text_colour: Colour type representing the colour of the message
+        message: String representing the error message that displays on the
+        overlay
+        client: MQTT Client which is used to check if client is connected
     """
 
+    # These class variables must be consistent for every instance
     text_colour = Colour.red
     message = "Message: DAS is disconnected. Connect to a broker."
 
-    def draw_data(self, canvas: Canvas, data: Data):
-        """Set up the disconnected message and pass it into the
-        display_message method.
+    def __init__(self, client):
+        """Assign client as an instance variable to check whether client used
+        for the overlay is connected."""
+        self.client = client
 
-        Display message only whenever DAS is disconnected or overlay is not
-        connected to broker.
-        """
-        self._display_message(
-            canvas,
-            DASDisconnectMessage.message,
-            DASDisconnectMessage.text_colour,
-        )
+    def draw_data(self, canvas: Canvas, data: Data) -> None:
+        """Display message only whenever DAS is disconnected or overlay is not
+        connected to broker."""
+        if not self.client.is_connected():
+            self._display_message(
+                canvas,
+                DASDisconnectMessage.message,
+                DASDisconnectMessage.text_colour,
+            )

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -21,6 +21,8 @@ class DASDisconnectMessage(Message):
         Display message only whenever DAS is disconnected or overlay is not
         connected to broker.
         """
-        self.display_message(
-            canvas, DASDisconnectMessage.message, DASDisconnectMessage.text_colour
+        self._display_message(
+            canvas,
+            DASDisconnectMessage.message,
+            DASDisconnectMessage.text_colour,
         )

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -4,8 +4,10 @@ from data import Data
 
 
 class DASDisconnectMessage(Message):
-    """Class displays error message on overlay when DAS is not connected, or
-    overlay is not connected to an MQTT broker.
+    """Class displays error message on overlay when DAS is not connected.
+
+    Message can only be received when the DAS is not connected. Will
+    disappear instantly once connected.
 
     Attributes:
         text_colour: Colour type representing the colour of the message
@@ -14,7 +16,6 @@ class DASDisconnectMessage(Message):
         client: MQTT Client which is used to check if client is connected
     """
 
-    # These class variables must be consistent for every instance
     text_colour = Colour.red
     message = "Message: DAS is disconnected, ensure it is turned on."
 

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -4,10 +4,11 @@ from data import Data
 
 
 class DASDisconnectMessage(Message):
-    """Class displays error message on overlay when DAS is not connected.
+    """Class will display an error message on the overlay that the DAS is not
+    connected.
 
-    Message can only be received when the DAS is not connected. Will
-    disappear instantly once connected.
+    Only displays when DAS is disconnected. Disappears immediately as soon
+    as it is connected.
 
     Attributes:
         text_colour: Colour type representing the colour of the message

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -1,9 +1,10 @@
 from components.message import Message
-from canvas import Colour
+from canvas import Canvas, Colour
+
 
 class DASDisconnectMessage(Message):
     text_colour = Colour.red
 
-    def draw_data(self, canvas: Canvas, data: Data):
+    def draw_data(self, canvas: Canvas):
         disconnected_message = "Message: DAS is disconnected. Connect to a broker."
-        self.display_message(canvas, disconnected_message, text_colour)
+        self.display_message(canvas, disconnected_message, DASDisconnectMessage.text_colour)

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -1,29 +1,26 @@
 from components.message import Message
 from canvas import Canvas, Colour
+from data import Data
 
 
 class DASDisconnectMessage(Message):
     """Class displays error message on overlay when DAS is not
     connected, or overlay is not connected to an MQTT broker.
 
-    Extends the Message class.
-
     Attributes:
         text_colour: Colour type representing the colour of the message
     """
 
     text_colour = Colour.red
+    message = "Message: DAS is disconnected. Connect to a broker."
 
-    def draw_data(self, canvas: Canvas):
+    def draw_data(self, canvas: Canvas, data: Data):
         """Set up the disconnected message and pass it into the
         display_message method.
 
         Display message only whenever DAS is disconnected or overlay is not
         connected to broker.
         """
-        disconnected_message = (
-            "Message: DAS is disconnected. Connect to a broker."
-        )
         self.display_message(
-            canvas, disconnected_message, DASDisconnectMessage.text_colour
+            canvas, DASDisconnectMessage.message, DASDisconnectMessage.text_colour
         )

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -1,4 +1,4 @@
-from components.message import Message
+from components import Message
 from canvas import Canvas, Colour
 from data import Data
 

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -16,7 +16,7 @@ class DASDisconnectMessage(Message):
 
     # These class variables must be consistent for every instance
     text_colour = Colour.red
-    message = "Message: DAS is disconnected. Connect to a broker."
+    message = "Message: DAS is disconnected, ensure it is turned on."
 
     def __init__(self, client):
         """Assign client as an instance variable to check whether client used
@@ -24,8 +24,6 @@ class DASDisconnectMessage(Message):
         self.client = client
 
     def draw_data(self, canvas: Canvas, data: Data) -> None:
-        """Display message only whenever DAS is disconnected or overlay is not
-        connected to broker."""
         if not self.client.is_connected():
             self._display_message(
                 canvas,

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -3,9 +3,24 @@ from canvas import Canvas, Colour
 
 
 class DASDisconnectMessage(Message):
+    """Class displays error message on overlay when DAS is not
+    connected, or overlay is not connected to an MQTT broker.
+
+    Extends the Message class.
+
+    Attributes:
+        text_colour: Colour type representing the colour of the message
+    """
+
     text_colour = Colour.red
 
     def draw_data(self, canvas: Canvas):
+        """Set up the disconnected message and pass it into the
+        display_message method.
+
+        Display message only whenever DAS is disconnected or overlay is not
+        connected to broker.
+        """
         disconnected_message = (
             "Message: DAS is disconnected. Connect to a broker."
         )

--- a/components/das_disconnect_message.py
+++ b/components/das_disconnect_message.py
@@ -1,0 +1,9 @@
+from components.message import Message
+from canvas import Colour
+
+class DASDisconnectMessage(Message):
+    text_colour = Colour.red
+
+    def draw_data(self, canvas: Canvas, data: Data):
+        disconnected_message = "Message: DAS is disconnected. Connect to a broker."
+        self.display_message(canvas, disconnected_message, text_colour)

--- a/components/dashboard_message.py
+++ b/components/dashboard_message.py
@@ -1,4 +1,4 @@
-from components.message import Message
+from components import Message
 from canvas import Canvas
 from data import Data
 

--- a/components/dashboard_message.py
+++ b/components/dashboard_message.py
@@ -1,5 +1,5 @@
 from components.message import Message
-from canvas import Canvas, Colour
+from canvas import Canvas
 from data import Data
 
 

--- a/components/dashboard_message.py
+++ b/components/dashboard_message.py
@@ -13,4 +13,4 @@ class DAShboardMessage(Message):
             return
         message = data.get_message()
         display_str = f"Message: {message}"
-        self.display_message(canvas, display_str)
+        self._display_message(canvas, display_str)

--- a/components/dashboard_message.py
+++ b/components/dashboard_message.py
@@ -6,7 +6,7 @@ from data import Data
 class DAShboardMessage(Message):
     """Displays messages sent from the DAShboard onto the camera overlay.
 
-    Messages are only sent when the overlay is connected to the DAS.
+    Messages can only be received when the overlay is connected to the DAS.
     """
 
     def draw_data(self, canvas: Canvas, data: Data) -> None:

--- a/components/dashboard_message.py
+++ b/components/dashboard_message.py
@@ -1,0 +1,16 @@
+from components.message import Message
+from canvas import Canvas, Colour
+
+
+class DAShboardMessage(Message):
+    """Displays messages sent from the DAShboard onto the camera overlay.
+
+    Messages are only sent when the overlay is connected to the DAS.
+    """
+
+    def draw_data(self, canvas: Canvas, data: Data) -> None:
+        if not data.has_message():
+            return
+        message = data.get_message()
+        display_str = f"Message: {message}"
+        self.display_message(canvas, display_str)

--- a/components/dashboard_message.py
+++ b/components/dashboard_message.py
@@ -1,5 +1,6 @@
 from components.message import Message
 from canvas import Canvas, Colour
+from data import Data
 
 
 class DAShboardMessage(Message):

--- a/components/message.py
+++ b/components/message.py
@@ -1,12 +1,12 @@
 from textwrap import wrap
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from canvas import Canvas, Colour
 from components import Component
 from data import Data
 
 
-class Message(Component, ABC):
+class Message(Component):
     """Abstract class for messages to display on the camera overlay.
 
     Lines are wrapped appropriately to ensure the entire message is

--- a/components/message.py
+++ b/components/message.py
@@ -1,9 +1,7 @@
 from textwrap import wrap
-from abc import abstractmethod
 
 from canvas import Canvas, Colour
 from components import Component
-from data import Data
 
 
 class Message(Component):

--- a/components/message.py
+++ b/components/message.py
@@ -30,7 +30,9 @@ class Message(Component):
     def display_message(
         self, canvas: Canvas, message: str, colour: Colour = Colour.black
     ):
-        """Display message on data overlay by wrapping each line starting from the top."""
+        """ Display message on data overlay by wrapping each line starting
+            from the top."""
+
         line_y_coord = Message.spacing + Message.text_height
         for line in wrap(message, Message.chars_per_line):
             coord = (Message.spacing, line_y_coord)

--- a/components/message.py
+++ b/components/message.py
@@ -28,10 +28,6 @@ class Message(Component):
     def draw_base(self, canvas: Canvas):
         pass
 
-    @abstractmethod
-    def draw_data(self, canvas: Canvas, data: Data):
-        pass
-
     def _display_message(
         self, canvas: Canvas, message: str, colour: Colour = Colour.black
     ):

--- a/components/message.py
+++ b/components/message.py
@@ -1,6 +1,6 @@
 from textwrap import wrap
 
-from canvas import Canvas
+from canvas import Canvas, Colour
 from components import Component
 from data import Data
 

--- a/components/message.py
+++ b/components/message.py
@@ -32,7 +32,7 @@ class Message(Component, ABC):
     def draw_data(self, canvas: Canvas, data: Data):
         pass
 
-    def display_message(
+    def _display_message(
         self, canvas: Canvas, message: str, colour: Colour = Colour.black
     ):
         """Display message on data overlay by wrapping each line starting

--- a/components/message.py
+++ b/components/message.py
@@ -7,7 +7,8 @@ from components import Component
 class Message(Component):
     """Abstract class for messages to display on the camera overlay.
 
-    Lines are wrapped appropriately to ensure the entire message is
+    Messages are shown on the top left corner of the overlay. Lines
+    are wrapped appropriately to ensure the entire message is
     visible.
 
     Attributes:

--- a/components/message.py
+++ b/components/message.py
@@ -11,7 +11,7 @@ class Message(Component, ABC):
 
     Lines are wrapped appropriately to ensure the entire message is
     visible.
-    
+
     Attributes:
         text_size: Integer for the text size on Canvas
         spacing: Integer for the spacing between lines of text

--- a/components/message.py
+++ b/components/message.py
@@ -25,10 +25,14 @@ class Message(Component):
             return
         message = data.get_message()
         display_str = f"Message: {message}"
+        self.display_message(canvas, display_str)
 
-        # Display each line of the message
+    def display_message(
+        self, canvas: Canvas, message: str, colour: Colour = Colour.black
+    ):
+        """Display message on data overlay by wrapping each line starting from the top."""
         line_y_coord = Message.spacing + Message.text_height
-        for line in wrap(display_str, Message.chars_per_line):
+        for line in wrap(message, Message.chars_per_line):
             coord = (Message.spacing, line_y_coord)
-            canvas.draw_text(line, coord, Message.text_size)
+            canvas.draw_text(line, coord, Message.text_size, colour)
             line_y_coord += Message.text_height + Message.spacing

--- a/components/message.py
+++ b/components/message.py
@@ -7,10 +7,17 @@ from data import Data
 
 
 class Message(Component, ABC):
-    """ AbstractDisplays any existing messages at the top of the screen.
+    """Abstract class for messages to display on the camera overlay.
 
-        Lines are wrapped appropriately to ensure the entire message is
-        visible. """
+    Lines are wrapped appropriately to ensure the entire message is
+    visible.
+    
+    Attributes:
+        text_size: Integer for the text size on Canvas
+        spacing: Integer for the spacing between lines of text
+        text_height: Integer for the height of a line of text
+        chars_per_line: Integer representing the number of characters per line
+    """
 
     text_size = 1
     spacing = 10
@@ -28,8 +35,8 @@ class Message(Component, ABC):
     def display_message(
         self, canvas: Canvas, message: str, colour: Colour = Colour.black
     ):
-        """ Display message on data overlay by wrapping each line starting
-            from the top."""
+        """Display message on data overlay by wrapping each line starting
+        from the top."""
 
         line_y_coord = Message.spacing + Message.text_height
         for line in wrap(message, Message.chars_per_line):

--- a/components/message.py
+++ b/components/message.py
@@ -1,12 +1,13 @@
 from textwrap import wrap
+from abc import ABC, abstractmethod
 
 from canvas import Canvas, Colour
 from components import Component
 from data import Data
 
 
-class Message(Component):
-    """ Displays any existing messages at the top of the screen.
+class Message(Component, ABC):
+    """ AbstractDisplays any existing messages at the top of the screen.
 
         Lines are wrapped appropriately to ensure the entire message is
         visible. """
@@ -20,12 +21,9 @@ class Message(Component):
     def draw_base(self, canvas: Canvas):
         pass
 
+    @abstractmethod
     def draw_data(self, canvas: Canvas, data: Data):
-        if not data.has_message():
-            return
-        message = data.get_message()
-        display_str = f"Message: {message}"
-        self.display_message(canvas, display_str)
+        pass
 
     def display_message(
         self, canvas: Canvas, message: str, colour: Colour = Colour.black

--- a/overlay.py
+++ b/overlay.py
@@ -175,6 +175,13 @@ class Overlay(ABC):
         self.client.subscribe(str(DAShboard.recording))
         with self.exception_handler:
             self.on_connect(client, userdata, flags, rc)
+        print("Connected with rc: {}".format(rc))
+
+    def on_connect(self, client, userdata, flags, rc):
+        """ Called automatically when the overlay connects successfully to the
+            MQTT broker.
+
+            Overlay implementations may override for one-off operations."""
 
     def on_data_message(self, client, userdata, msg):
         with self.exception_handler:
@@ -186,13 +193,6 @@ class Overlay(ABC):
             self.backend.start_recording()
         elif DAShboard.recording_stop.matches(msg.topic):
             self.backend.stop_recording()
-
-    @abstractmethod
-    def on_connect(self, client, userdata, flags, rc):
-        """ Called automatically when the overlay connects successfully to the
-            MQTT broker.
-
-            Overlay implementations may override for one-off operations."""
 
     def draw_base_layer(self):
         """ Set up the base layer as soon as camera turns on.

--- a/overlay.py
+++ b/overlay.py
@@ -81,7 +81,7 @@ class Overlay(ABC):
 
     def connect(self, ip="192.168.100.100", port=1883):
         self.client.connect_async(ip, port, 60)
-        self.display_base_layer()
+        self.draw_base_layer()
 
         with self.exception_handler:
             with BackendFactory.create(
@@ -188,15 +188,15 @@ class Overlay(ABC):
             Overlay implementations may override for one-off operations."""
         pass
 
-    def display_base_layer(self):
+    def draw_base_layer(self):
         """ Set up the base layer as soon as camera turns on.
 
             Method only needs to be called once. Should also catch any errors
             that occur when base layer is displayed. """
         with self.exception_handler:
-            self._display_base_layer()
+            self._draw_base_layer()
 
-    def _display_base_layer(self):
+    def _draw_base_layer(self):
         """ Called immediately once camera turns on.
 
             Overlay implementations should override this method with code which

--- a/overlay.py
+++ b/overlay.py
@@ -96,6 +96,7 @@ class Overlay(ABC):
 
                 if self.backend_name == "opencv_static_image":
                     self.backend.set_background(self.bg_path)
+                self.backend.on_base_canvas_updated(self.base_canvas)
 
                 # mqtt loop (does not block)
                 self.client.loop_start()
@@ -169,7 +170,6 @@ class Overlay(ABC):
         self.client.subscribe(str(DAShboard.recording))
         with self.exception_handler:
             self.on_connect(client, userdata, flags, rc)
-        self.backend.on_base_canvas_updated(self.base_canvas)
         self.client.is_connected = True
 
     def on_data_message(self, client, userdata, msg):

--- a/overlay.py
+++ b/overlay.py
@@ -82,6 +82,7 @@ class Overlay(ABC):
 
     def connect(self, ip="192.168.100.100", port=1883):
         self.client.connect_async(ip, port, 60)
+        self.display_base_layer()
 
         with self.exception_handler:
             with BackendFactory.create(
@@ -187,8 +188,22 @@ class Overlay(ABC):
         """ Called automatically when the overlay connects successfully to the
             MQTT broker.
 
-            Overlay implementations may override for one-off operations
-            (e.g. drawing self.base_canvas) """
+            Overlay implementations may override for one-off operations."""
+        pass
+
+    def display_base_layer(self):
+        """ Set up the base layer as soon as camera turns on.
+        
+            Method only needs to be called once. Should also catch any errors
+            that occur when base layer is displayed. """
+        with self.exception_handler:
+            self._display_base_layer()
+
+    def _display_base_layer(self):
+        """ Called immediately once camera turns on.
+        
+            Overlay implementations should override this method with code which
+            displays self.base_canvas. """
         pass
 
     def update_data_layer(self):

--- a/overlay.py
+++ b/overlay.py
@@ -94,7 +94,8 @@ class Overlay(ABC):
 
                 if self.backend_name == "opencv_static_image":
                     self.backend.set_background(self.bg_path)
-
+                self.backend.on_base_canvas_updated(self.base_canvas)
+                
                 # mqtt loop (does not block)
                 self.client.loop_start()
 
@@ -169,7 +170,6 @@ class Overlay(ABC):
         self.client.subscribe(str(DAShboard.recording))
         with self.exception_handler:
             self.on_connect(client, userdata, flags, rc)
-        self.backend.on_base_canvas_updated(self.base_canvas)
 
     def on_data_message(self, client, userdata, msg):
         with self.exception_handler:

--- a/overlay.py
+++ b/overlay.py
@@ -28,9 +28,6 @@ class Overlay(ABC):
         self.data_canvas = Canvas(self.width, self.height)
         self.message_canvas = Canvas(self.width, self.height)
 
-        # Time between updating the data layer in seconds
-        self.data_update_interval = 1
-
         # Raspicam Backend set up
         self.backend = None
         self.bg_path = None
@@ -69,6 +66,9 @@ class Overlay(ABC):
         self.exception_handler = CameraErrorHandler(
             self.client, self.device, self.backend_name, self.bg_path, configs
         )
+
+        # Time between updating the data layer in seconds
+        self.data_update_interval = 1
 
         self.start_time = time.time()
 

--- a/overlay.py
+++ b/overlay.py
@@ -50,6 +50,7 @@ class Overlay(ABC):
         self.client.on_connect = self._on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.on_log = self.on_log
+        self.client.is_connected = False # Default is false until connected
 
         # Set the video feed status to offline if connection breaks
         video_topic = f"{str(DAShboard.status_video_feed)}/{self.device}"
@@ -170,6 +171,7 @@ class Overlay(ABC):
         self.client.subscribe(str(DAShboard.recording))
         with self.exception_handler:
             self.on_connect(client, userdata, flags, rc)
+        self.client.is_connected = True
 
     def on_data_message(self, client, userdata, msg):
         with self.exception_handler:

--- a/overlay.py
+++ b/overlay.py
@@ -161,6 +161,7 @@ class Overlay(ABC):
 
     def on_disconnect(self, client, userdata, msg):
         print("Disconnected from broker")
+        self.client.is_connected = False
 
     def _on_connect(self, client, userdata, flags, rc):
         self.subscribe_to_topic_list(self.data.get_topics())

--- a/overlay.py
+++ b/overlay.py
@@ -50,7 +50,6 @@ class Overlay(ABC):
         self.client.on_connect = self._on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.on_log = self.on_log
-        self.client.is_connected = False  # Default is false until connected
 
         # Set the video feed status to offline if connection breaks
         video_topic = f"{str(DAShboard.status_video_feed)}/{self.device}"
@@ -163,14 +162,12 @@ class Overlay(ABC):
 
     def on_disconnect(self, client, userdata, msg):
         print("Disconnected from broker")
-        self.client.is_connected = False
 
     def _on_connect(self, client, userdata, flags, rc):
         self.subscribe_to_topic_list(self.data.get_topics())
         self.client.subscribe(str(DAShboard.recording))
         with self.exception_handler:
             self.on_connect(client, userdata, flags, rc)
-        self.client.is_connected = True
 
     def on_data_message(self, client, userdata, msg):
         with self.exception_handler:

--- a/overlay.py
+++ b/overlay.py
@@ -193,7 +193,7 @@ class Overlay(ABC):
 
     def display_base_layer(self):
         """ Set up the base layer as soon as camera turns on.
-        
+
             Method only needs to be called once. Should also catch any errors
             that occur when base layer is displayed. """
         with self.exception_handler:
@@ -201,7 +201,7 @@ class Overlay(ABC):
 
     def _display_base_layer(self):
         """ Called immediately once camera turns on.
-        
+
             Overlay implementations should override this method with code which
             displays self.base_canvas. """
         pass

--- a/overlay.py
+++ b/overlay.py
@@ -96,7 +96,7 @@ class Overlay(ABC):
                 if self.backend_name == "opencv_static_image":
                     self.backend.set_background(self.bg_path)
                 self.backend.on_base_canvas_updated(self.base_canvas)
-                
+
                 # mqtt loop (does not block)
                 self.client.loop_start()
 

--- a/overlay.py
+++ b/overlay.py
@@ -95,16 +95,12 @@ class Overlay(ABC):
 
                 if self.backend_name == "opencv_static_image":
                     self.backend.set_background(self.bg_path)
-                self.backend.on_base_canvas_updated(self.base_canvas)
 
                 # mqtt loop (does not block)
                 self.client.loop_start()
 
-                prev_data_update = (
-                    0  # time that we last updated the data layer
-                )
+                prev_data_update = 0 # time when data layer was updated
                 while True:
-
                     # Update data overlay only if we have waited enough time
                     if (
                         time.time()
@@ -171,6 +167,7 @@ class Overlay(ABC):
         self.client.subscribe(str(DAShboard.recording))
         with self.exception_handler:
             self.on_connect(client, userdata, flags, rc)
+        self.backend.on_base_canvas_updated(self.base_canvas)
         self.client.is_connected = True
 
     def on_data_message(self, client, userdata, msg):

--- a/overlay.py
+++ b/overlay.py
@@ -19,12 +19,19 @@ DEFAULT_BIKE = "V2"
 class Overlay(ABC):
     def __init__(self, bike, width=1280, height=740, bg: str = None):
 
+        # Overlay dimension sizes
         self.width = width
         self.height = height
 
-        # Time between updating the data layer, in seconds
+        # Canvas set up
+        self.base_canvas = Canvas(self.width, self.height)
+        self.data_canvas = Canvas(self.width, self.height)
+        self.message_canvas = Canvas(self.width, self.height)
+
+        # Time between updating the data layer in seconds
         self.data_update_interval = 1
 
+        # Raspicam Backend set up
         self.backend = None
         self.bg_path = None
         if bg is not None:
@@ -36,10 +43,7 @@ class Overlay(ABC):
         else:
             self.backend_name = "opencv"
 
-        self.base_canvas = Canvas(self.width, self.height)
-        self.data_canvas = Canvas(self.width, self.height)
-        self.message_canvas = Canvas(self.width, self.height)
-
+        # Bike configuration set up
         configs = read_configs()
         bike_version = bike or configs["bike"] or DEFAULT_BIKE
         self.data = DataFactory.create(bike_version)
@@ -101,7 +105,9 @@ class Overlay(ABC):
                 # mqtt loop (does not block)
                 self.client.loop_start()
 
-                prev_data_update = 0  # time when data layer was updated
+                # Time when data layer was updated
+                prev_data_update = 0
+
                 while True:
                     # Update data overlay only if we have waited enough time
                     if (

--- a/overlay.py
+++ b/overlay.py
@@ -186,7 +186,6 @@ class Overlay(ABC):
             MQTT broker.
 
             Overlay implementations may override for one-off operations."""
-        pass
 
     def draw_base_layer(self):
         """ Set up the base layer as soon as camera turns on.
@@ -196,12 +195,12 @@ class Overlay(ABC):
         with self.exception_handler:
             self._draw_base_layer()
 
+    @abstractmethod
     def _draw_base_layer(self):
         """ Called immediately once camera turns on.
 
             Overlay implementations should override this method with code which
             displays self.base_canvas. """
-        pass
 
     def update_data_layer(self):
         """ Update the data layer of the overlay at a regular interval.
@@ -218,7 +217,6 @@ class Overlay(ABC):
 
             Overlay implementations should override this method with code which
             updates self.data_canvas. """
-        pass
 
     @staticmethod
     def get_overlay_args(overlay_description: str):

--- a/overlay.py
+++ b/overlay.py
@@ -50,6 +50,7 @@ class Overlay(ABC):
         self.client.on_connect = self._on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.on_log = self.on_log
+        self.client.reconnect_delay_set(max_delay=10)
 
         # Set the video feed status to offline if connection breaks
         video_topic = f"{str(DAShboard.status_video_feed)}/{self.device}"

--- a/overlay.py
+++ b/overlay.py
@@ -50,7 +50,7 @@ class Overlay(ABC):
         self.client.on_connect = self._on_connect
         self.client.on_disconnect = self.on_disconnect
         self.client.on_log = self.on_log
-        self.client.is_connected = False # Default is false until connected
+        self.client.is_connected = False  # Default is false until connected
 
         # Set the video feed status to offline if connection breaks
         video_topic = f"{str(DAShboard.status_video_feed)}/{self.device}"
@@ -100,7 +100,7 @@ class Overlay(ABC):
                 # mqtt loop (does not block)
                 self.client.loop_start()
 
-                prev_data_update = 0 # time when data layer was updated
+                prev_data_update = 0  # time when data layer was updated
                 while True:
                     # Update data overlay only if we have waited enough time
                     if (

--- a/overlay_all_stats.py
+++ b/overlay_all_stats.py
@@ -10,8 +10,6 @@ class OverlayAllStats(Overlay):
         self.message_received_time = 0
 
     def on_connect(self, client, userdata, flags, rc):
-        print("Connected with rc: {}".format(rc))
-
         # Add static text
         self.base_canvas.draw_text("REC Power:", (5, self.text_height * 1))
         self.base_canvas.draw_text("Power:", (5, self.text_height * 2))

--- a/overlay_all_stats.py
+++ b/overlay_all_stats.py
@@ -9,7 +9,7 @@ class OverlayAllStats(Overlay):
         self.speed_height = 70
         self.message_received_time = 0
 
-    def on_connect(self, client, userdata, flags, rc):
+    def _draw_base_layer(self):
         # Add static text
         self.base_canvas.draw_text("REC Power:", (5, self.text_height * 1))
         self.base_canvas.draw_text("Power:", (5, self.text_height * 2))

--- a/overlay_blank.py
+++ b/overlay_blank.py
@@ -6,7 +6,7 @@ class OverlayBlank(Overlay):
     def __init__(self, bike=None, bg=None):
         super(OverlayBlank, self).__init__(bike, bg=bg)
 
-    def on_connect(self, client, userdata, flags, rc):
+    def _draw_base_layer(self):
         # To draw static text/whatever onto the overlay,
         # draw on the base canvas
         self.base_canvas.draw_text(

--- a/overlay_blank.py
+++ b/overlay_blank.py
@@ -7,8 +7,6 @@ class OverlayBlank(Overlay):
         super(OverlayBlank, self).__init__(bike, bg=bg)
 
     def on_connect(self, client, userdata, flags, rc):
-        print("Connected with rc: {}".format(rc))
-
         # To draw static text/whatever onto the overlay,
         # draw on the base canvas
         self.base_canvas.draw_text(

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -1,4 +1,4 @@
-from components import DataField, SpeedField, CentrePower, Message
+from components import DataField, SpeedField, CentrePower, Message, DASDisconnectMessage
 from overlay import Overlay
 
 
@@ -56,8 +56,9 @@ class OverlayNew(Overlay):
                 data_field_coord(3, 1),
             ),
             CentrePower(self.width, self.height),
-            Message(),
+            Message()
         ]
+        self.das_disconnect_message = DASDisconnectMessage()
 
     def on_connect(self, client, userdata, flags, rc):
         print("Connected with rc: {}".format(rc))
@@ -67,6 +68,9 @@ class OverlayNew(Overlay):
 
     def _update_data_layer(self):
         self.data_canvas.clear()
+
+        if not self.client.is_connected:
+            self.das_disconnect_message.draw_data(self.data_canvas)
 
         for component in self.components:
             component.draw_data(self.data_canvas, self.data)

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -1,4 +1,10 @@
-from components import DataField, SpeedField, CentrePower, Message, DASDisconnectMessage
+from components import (
+    DataField,
+    SpeedField,
+    CentrePower,
+    Message,
+    DASDisconnectMessage,
+)
 from overlay import Overlay
 
 
@@ -56,7 +62,7 @@ class OverlayNew(Overlay):
                 data_field_coord(3, 1),
             ),
             CentrePower(self.width, self.height),
-            Message()
+            Message(),
         ]
         self.das_disconnect_message = DASDisconnectMessage()
 

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -66,9 +66,6 @@ class OverlayNew(Overlay):
             DASDisconnectMessage(self.client),
         ]
 
-    def on_connect(self, client, userdata, flags, rc):
-        print("Connected with rc: {}".format(rc))
-
     def _draw_base_layer(self):
         for component in self.components:
             component.draw_base(self.base_canvas)

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -76,7 +76,7 @@ class OverlayNew(Overlay):
     def _update_data_layer(self):
         self.data_canvas.clear()
 
-        if not self.client.is_connected:
+        if not self.client.is_connected():
             self.das_disconnect_message.draw_data(self.data_canvas)
 
         for component in self.components:

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -63,6 +63,7 @@ class OverlayNew(Overlay):
     def on_connect(self, client, userdata, flags, rc):
         print("Connected with rc: {}".format(rc))
 
+    def _display_base_layer(self):
         for component in self.components:
             component.draw_base(self.base_canvas)
 

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -2,7 +2,7 @@ from components import (
     DataField,
     SpeedField,
     CentrePower,
-    Message,
+    DAShboardMessage,
     DASDisconnectMessage,
 )
 from overlay import Overlay
@@ -62,22 +62,19 @@ class OverlayNew(Overlay):
                 data_field_coord(3, 1),
             ),
             CentrePower(self.width, self.height),
-            Message(),
+            DAShboardMessage(),
+            DASDisconnectMessage(self.client),
         ]
-        self.das_disconnect_message = DASDisconnectMessage()
 
     def on_connect(self, client, userdata, flags, rc):
         print("Connected with rc: {}".format(rc))
 
-    def _display_base_layer(self):
+    def _draw_base_layer(self):
         for component in self.components:
             component.draw_base(self.base_canvas)
 
     def _update_data_layer(self):
         self.data_canvas.clear()
-
-        if not self.client.is_connected():
-            self.das_disconnect_message.draw_data(self.data_canvas)
 
         for component in self.components:
             component.draw_data(self.data_canvas, self.data)

--- a/overlay_top_strip.py
+++ b/overlay_top_strip.py
@@ -17,7 +17,7 @@ class OverlayTopStrip(Overlay):
         self.top_box_width = self.width
         self.top_text_pos = self.top_box_height - 15
 
-    def on_connect(self, client, userdata, flags, rc):
+    def _draw_base_layer(self):
         self.base_canvas.draw_rect(
             (0, 0), (self.top_box_width, self.top_box_height)
         )

--- a/overlay_top_strip.py
+++ b/overlay_top_strip.py
@@ -18,8 +18,6 @@ class OverlayTopStrip(Overlay):
         self.top_text_pos = self.top_box_height - 15
 
     def on_connect(self, client, userdata, flags, rc):
-        print("Connected with rc: " + str(rc))
-
         self.base_canvas.draw_rect(
             (0, 0), (self.top_box_width, self.top_box_height)
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -178,7 +178,7 @@ description = "Python plotting package"
 name = "matplotlib"
 optional = false
 python-versions = ">=3.6"
-version = "3.3.1"
+version = "3.3.2"
 
 [package.dependencies]
 certifi = ">=2020.06.20"
@@ -488,7 +488,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "0b0123132f02b75fa0d54c2f2ade03310db926355ce252028f51ad0045ac26c7"
+content-hash = "62eb0450db6baeeea2b384841b33a22250f1d9c0beeb212efa71104e31ce092d"
 lock-version = "1.0"
 python-versions = "~3.7"
 
@@ -590,33 +590,24 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
 ]
 matplotlib = [
-    {file = "matplotlib-3.3.1-1-cp36-cp36m-win32.whl", hash = "sha256:fab11637734eb14affb9c5e20d44d69429c18b49595d6e67c69295de24827fc4"},
-    {file = "matplotlib-3.3.1-1-cp36-cp36m-win_amd64.whl", hash = "sha256:24392ac1a382ed753505286f1a1483bcfd67ed0c72d51be10c4c2013e386d0b7"},
-    {file = "matplotlib-3.3.1-1-cp37-cp37m-win32.whl", hash = "sha256:c4ffb25b9855bdb6cdaf21bbd4ab2c229be539248304ac5215b94c816ea6e32e"},
-    {file = "matplotlib-3.3.1-1-cp37-cp37m-win_amd64.whl", hash = "sha256:5a42c84264a1acbbf01c073a7bd05a0e80d99f94f10020d613b1b0526af9dcc2"},
-    {file = "matplotlib-3.3.1-1-cp38-cp38-win32.whl", hash = "sha256:bc978374b43737f2bbc4a6ec48e52ae8c92be6278a80d0e2ce92f0eb0841f15c"},
-    {file = "matplotlib-3.3.1-1-cp38-cp38-win_amd64.whl", hash = "sha256:6d0f03079f655ca0a2d2e0bf49c28e1ec43d9d544c33d8da1a88765f23018ecc"},
-    {file = "matplotlib-3.3.1-1-cp39-cp39-win32.whl", hash = "sha256:2375f039b8c6ad6c1d03f01bf31f086bbbf997bf25e246f3b67f69969cde3d98"},
-    {file = "matplotlib-3.3.1-1-cp39-cp39-win_amd64.whl", hash = "sha256:233bef5e3b3494f3b7057595ca814f23ba0ce67a03632ddf677be5132128b3db"},
-    {file = "matplotlib-3.3.1-1-pp36-pypy36_pp73-win32.whl", hash = "sha256:f62c0b9a5d38c26673a8862cbae4d26cffcda260848e4278246b4e00f5a95eaf"},
-    {file = "matplotlib-3.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:282f8a077a1217f9f2ac178596f27c1ae94abbc6e7b785e1b8f25e83918e9199"},
-    {file = "matplotlib-3.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:83ae7261f4d5ab387be2caee29c4f499b1566f31c8ac97a0b8ab61afd9e3da92"},
-    {file = "matplotlib-3.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1f9cf2b8500b833714a193cb24281153f5072d55b2e486009f1e81f0b7da3410"},
-    {file = "matplotlib-3.3.1-cp36-cp36m-win32.whl", hash = "sha256:0dc15e1ad84ec06bf0c315e6c4c2cced13a21ce4c2b4955bb75097064a4b1e92"},
-    {file = "matplotlib-3.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:ffbae66e2db70dc330cb3299525f97e1c0efdfc763e04e1a4e08f968c7ad21f0"},
-    {file = "matplotlib-3.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88c6ab4a32a7447dad236b8371612aaba5c967d632ff11999e0478dd687f2c58"},
-    {file = "matplotlib-3.3.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cc2d6b47c8fee89da982a312b54949ec0cd6a7976a8cafb5b62dea6c9883a14d"},
-    {file = "matplotlib-3.3.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:636c6330a7dcb18bac114dbeaff314fbbb0c11682f9a9601de69a50e331d18d7"},
-    {file = "matplotlib-3.3.1-cp37-cp37m-win32.whl", hash = "sha256:73a493e340064e8fe03207d9333b68baca30d9f0da543ae4af6b6b4f13f0fe05"},
-    {file = "matplotlib-3.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6739b6cd9278d5cb337df0bd4400ad37bbd04c6dc7aa2c65e1e83a02bc4cc6fd"},
-    {file = "matplotlib-3.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:79f0c4730ad422ecb6bda814c9a9b375df36d6bd5a49eaa14e92e5f5e3e95ac3"},
-    {file = "matplotlib-3.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e4d6d3afc454b4afc0d9d0ed52a8fa40a1b0d8f33c8e143e49a5833a7e32266b"},
-    {file = "matplotlib-3.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:96a5e667308dbf45670370d9dffb974e73b15bac0df0b5f3fb0b0ac7a572290e"},
-    {file = "matplotlib-3.3.1-cp38-cp38-win32.whl", hash = "sha256:bd8fceaa3494b531d43b6206966ba15705638137fc2dc5da5ee560cf9476867b"},
-    {file = "matplotlib-3.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:1507c2a8e4662f6fa1d3ecc760782b158df8a3244ecc21c1d8dbb1cd0b3f872e"},
-    {file = "matplotlib-3.3.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2c3619ec2a5ead430a4536ebf8c77ea55d8ce36418919f831d35bc657ed5f27e"},
-    {file = "matplotlib-3.3.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:9703bc00a94a94c4e94b2ea0fbfbc9d2bb21159733134639fd931b6606c5c47e"},
-    {file = "matplotlib-3.3.1.tar.gz", hash = "sha256:87f53bcce90772f942c2db56736788b39332d552461a5cb13f05ff45c1680f0e"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:27f9de4784ae6fb97679556c5542cf36c0751dccb4d6407f7c62517fa2078868"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:06866c138d81a593b535d037b2727bec9b0818cadfe6a81f6ec5715b8dd38a89"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5ccecb5f78b51b885f0028b646786889f49c54883e554fca41a2a05998063f23"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-win32.whl", hash = "sha256:69cf76d673682140f46c6cb5e073332c1f1b2853c748dc1cb04f7d00023567f7"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-win_amd64.whl", hash = "sha256:371518c769d84af8ec9b7dcb871ac44f7a67ef126dd3a15c88c25458e6b6d205"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:793e061054662aa27acaff9201cdd510a698541c6e8659eeceb31d66c16facc6"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:16b241c3d17be786966495229714de37de04472da472277869b8d5b456a8df00"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3fb0409754b26f48045bacd6818e44e38ca9338089f8ba689e2f9344ff2847c7"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:548cfe81476dbac44db96e9c0b074b6fb333b4d1f12b1ae68dbed47e45166384"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f0268613073df055bcc6a490de733012f2cf4fe191c1adb74e41cec8add1a165"},
+    {file = "matplotlib-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:57be9e21073fc367237b03ecac0d9e4b8ddbe38e86ec4a316857d8d93ac9286c"},
+    {file = "matplotlib-3.3.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:be2f0ec62e0939a9dcfd3638c140c5a74fc929ee3fd1f31408ab8633db6e1523"},
+    {file = "matplotlib-3.3.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c5d0c2ae3e3ed4e9f46b7c03b40d443601012ffe8eb8dfbb2bd6b2d00509f797"},
+    {file = "matplotlib-3.3.2-cp38-cp38-win32.whl", hash = "sha256:a522de31e07ed7d6f954cda3fbd5ca4b8edbfc592a821a7b00291be6f843292e"},
+    {file = "matplotlib-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:8bc1d3284dee001f41ec98f59675f4d723683e1cc082830b440b5f081d8e0ade"},
+    {file = "matplotlib-3.3.2-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:799c421bc245a0749c1515b6dea6dc02db0a8c1f42446a0f03b3b82a60a900dc"},
+    {file = "matplotlib-3.3.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:2f5eefc17dc2a71318d5a3496313be5c351c0731e8c4c6182c9ac3782cfc4076"},
+    {file = "matplotlib-3.3.2.tar.gz", hash = "sha256:3d2edbf59367f03cd9daf42939ca06383a7d7803e3993eb5ff1bee8e8a3fbb6b"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},


### PR DESCRIPTION
## Description

WOW ok I finished this PR quicker than I expected. GReat lol

When this PR is merged, it should:
- Display error message that the DAS is not connected to the overlay, or the broker has not initiated. 
  - Error message should disappear **only** when DAS is connected.
  - If DAS disconnects during the 'race', then the error message will reappear. 
  - Reconnect delay should also be changed to every 10 seconds. 
- Display data titles, even though data is not being sent to the overlay, when it didn't before.
- Add comment headers for the `Overlay` constructor in hopes that this will be more readable and organised.

The following changes are only applied to `overlay_new.py` at the moment. But I'm open to changing these for the other overlays if needed. 

ALSO, I'm open to any name changes for the new class `DASDisconnectMessage`, because it's quite long. But if everyone is cool with this, then I'm cool with it. 

## Screenshots

Initial version:
![image](https://user-images.githubusercontent.com/58575113/93505262-fb343980-f95d-11ea-840e-724ef2e8a728.png)

Updated version:
![image](https://user-images.githubusercontent.com/58575113/93604830-45262980-fa09-11ea-80f2-73d65b63591e.png)

## Steps to Test
Ensure that a `mosquitto` broker is **not** running in a terminal nor in the background. 

1. Run `poetry install`.
2. Run `poetry shell`.
3. Run `python overlay_new.py`.

To test if error message will disappear:

4. Run `mosquitto` in a terminal. Error message should disappear as soon as overlay is connected. 
