### PR TITLE
Add tests to check that overlays can be instantiated

### DIFF
--- a/tests/overlay_test.py
+++ b/tests/overlay_test.py
@@ -1,0 +1,25 @@
+from overlay_all_stats import OverlayAllStats
+from overlay_blank import OverlayBlank
+from overlay_new import OverlayNew
+from overlay_top_strip import OverlayTopStrip
+
+
+def test_overlay_all_stats_instantiation():
+    """ Check that OverlayAllStats can be instantiated """
+    OverlayAllStats("V3")
+
+
+def test_overlay_blank_instantiation():
+    """ Check that OverlayBlank can be instantiated """
+    OverlayBlank("V3")
+
+
+def test_overlay_new_instantiation():
+    """ Check that OverlayNew can be instantiated """
+    OverlayNew("V3")
+
+
+def test_overlay_top_strip_instantiation():
+    """ Check that OverlayTopStrip can be instantiated """
+    OverlayTopStrip("V3")
+

--- a/tests/overlay_test.py
+++ b/tests/overlay_test.py
@@ -22,4 +22,3 @@ def test_overlay_new_instantiation():
 def test_overlay_top_strip_instantiation():
     """ Check that OverlayTopStrip can be instantiated """
     OverlayTopStrip("V3")
-


### PR DESCRIPTION
## Description

I almost didn't notice we were about to break all overlays other than `OverlayNew` when reviewing #48. This quick PR adds some tests to check that all our overlays can be instantiated. Whether they can actually is another problem, one that I don't know if we can feasibly test on CICD, but this should at least catch some of our mistakes :)

## Screenshots

n/a

## Steps to Test

Run `pytest`, check that the tests pass.