### PR TITLE
Fix outdated WM topic usage

### DIFF
--- a/data.py
+++ b/data.py
@@ -197,7 +197,7 @@ class DataV3(Data):
     @staticmethod
     def get_topics() -> List[topics.Topic]:
         return [
-            topics.WirelessModule.data(),
+            topics.WirelessModule.all().data,
             topics.Camera.overlay_message,
             # TODO: BOOST currently publishes data in the deprecated V2 format
             # on the V3 topic. Uncomment below when updated.
@@ -211,7 +211,7 @@ class DataV3(Data):
         """
         if topic == topics.Camera.overlay_message:
             self.load_message_json(data)
-        elif topics.WirelessModule.data().matches(topic):
+        elif topics.WirelessModule.all().data.matches(topic):
             self.load_sensor_data(data)
         elif topic == topics.BOOST.recommended_sp:
             self.load_recommended_sp(data)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -176,10 +176,18 @@ class TestDataV3:
         }
 
         data = DataV3()
-        data.load_data(topics.WirelessModule.data(1), dumps(front_module_data))
-        data.load_data(topics.WirelessModule.data(2), dumps(mid_module_data))
-        data.load_data(topics.WirelessModule.data(3), dumps(back_module_data))
-        data.load_data(topics.WirelessModule.data(4), dumps(das_module_data))
+        data.load_data(
+            topics.WirelessModule.id(1).data, dumps(front_module_data)
+        )
+        data.load_data(
+            topics.WirelessModule.id(2).data, dumps(mid_module_data)
+        )
+        data.load_data(
+            topics.WirelessModule.id(3).data, dumps(back_module_data)
+        )
+        data.load_data(
+            topics.WirelessModule.id(4).data, dumps(das_module_data)
+        )
 
         # No fields tracked from front or mid module
         # Test back module


### PR DESCRIPTION
## Description

So, between when the last commit was pushed in #51 and when it was merged, the usage of `WirelessModule` topics was changed in monash-human-power/common/pull/12, and I forgot to update it here. CICD didn't pick it up because the change was after it run, but then I got a happy little email saying CICD failed when merging #51.

This quick PR updates the topic usage.

Also, isn't it great not having to have 3 people review my mistakes?

## Screenshots

![image](https://user-images.githubusercontent.com/17876556/102684239-edc36f80-422a-11eb-8e93-fc4f2f8fb0d5.png)

## Steps to Test

Run `pytest` (but CICD will do that for you)
