### PR TITLE
Add raspicam systemd services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MHP_Raspicam
+# MHP Raspicam
 [![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 
 This repo contains code used to run the Monash Human Power camera system. The `master` branch is write protected to ensure it is always left in a working state.
@@ -37,6 +37,18 @@ This repo contains code used to run the Monash Human Power camera system. The `m
 
     With that done, `raspicam` dependencies may be installed using `poetry install --dev`.
 
+6. **Install and enable `systemd` services (optional)**
+
+    If you are setting up `raspicam` on the actual display Pis, enable and start the `raspicam` services so that `raspicam` begins on startup.
+
+    ```bash
+    # Install the raspicam services
+    ./service/install.sh
+    # Enable running on boot, and start running now
+    systemctl --user enable --now raspicam-orchestrator
+    systemctl --user enable --now raspicam-switch
+    ```
+
 ## Usage
 
 **Important:** *You must be in a poetry shell to run any scripts/tests.* To start a poetry shell, run `poetry shell`. You may exit the shell at any time with `exit`.
@@ -49,7 +61,13 @@ Any overlay (e.g. `overlay_top_strip.py`) may be run from the terminal with Pyth
 
 If you are trying run an overlay over VNC, you will need to enable direct capture mode on the Pi's VNC server. Right click on the VNC logo in the Pi's system tray, click `Options -> Troubleshooting -> Enable direct capture mode -> OK`.
 
-Overlays may be run from the terminal, as before. However, for use on the bike, you should have `switch.py` and `orchestrator.py` running on startup. Currently, this is run automatically by `/etc/rc.local` on the display Pis, but they may also be run manually.
+Overlays may be run from the terminal, as before. However, for use on the bike, you should have `switch.py` and `orchestrator.py` running on startup using systemd services as described in [Installation](#installation). Once this is setup, you can view the output of the two scripts with
+
+```bash
+systemctl --user status raspicam-orchestrator
+```
+
+You may also find `systemctl`'s `start`, `stop`, `restart` and `disable` commands useful.
 
 ## Tests
 

--- a/config.py
+++ b/config.py
@@ -13,6 +13,7 @@ OVERLAY_FILE_PATTERN = "overlay_*.py"
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 DEFAULT_BROKER_IP = "192.168.100.100"
+DEFAULT_BIKE = "V2"
 
 
 def get_overlays(directory=CURRENT_DIRECTORY):
@@ -60,9 +61,15 @@ def read_configs(directory=CURRENT_DIRECTORY):
 
     configs["bike"] = os.getenv("MHP_BIKE")
     if not configs["bike"]:
-        warn("MHP_BIKE has not been set in .env")
+        warn(f"MHP_BIKE is not set in .env, defaulting to {DEFAULT_BIKE}")
+        configs["bike"] = DEFAULT_BIKE
 
-    configs["broker_ip"] = os.getenv("BROKER_IP") or DEFAULT_BROKER_IP
+    configs["broker_ip"] = os.getenv("BROKER_IP")
+    if not configs["broker_ip"]:
+        warn(
+            f"BROKER_IP is not set in .env, defaulting to {DEFAULT_BROKER_IP}"
+        )
+        configs["broker_ip"] = DEFAULT_BROKER_IP
 
     configs["overlays"] = get_overlays()
     return configs

--- a/config.py
+++ b/config.py
@@ -12,6 +12,8 @@ ACTIVE_OVERLAY_KEY = "activeOverlay"
 OVERLAY_FILE_PATTERN = "overlay_*.py"
 CURRENT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
+DEFAULT_BROKER_IP = "192.168.100.100"
+
 
 def get_overlays(directory=CURRENT_DIRECTORY):
     """Get overlays stored in directory"""
@@ -59,6 +61,8 @@ def read_configs(directory=CURRENT_DIRECTORY):
     configs["bike"] = os.getenv("MHP_BIKE")
     if not configs["bike"]:
         warn("MHP_BIKE has not been set in .env")
+
+    configs["broker_ip"] = os.getenv("BROKER_IP") or DEFAULT_BROKER_IP
 
     configs["overlays"] = get_overlays()
     return configs

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -14,11 +14,14 @@ import config
 
 def get_args(argv=[]):
     """Get arguments passed into Python script"""
-    parser = argparse.ArgumentParser()
+    configs = config.read_configs()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "--host",
         type=str,
-        default="192.168.100.100",
+        default=configs["broker_ip"],
         help="ip address of the broker",
     )
     return parser.parse_args(argv)

--- a/overlay.py
+++ b/overlay.py
@@ -227,14 +227,17 @@ class Overlay(ABC):
 
     @staticmethod
     def get_overlay_args(overlay_description: str):
+        configs = read_configs()
         parser = argparse.ArgumentParser(
-            description=overlay_description, add_help=True
+            description=overlay_description,
+            add_help=True,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )
         parser.add_argument(
             "--host",
             action="store",
             type=str,
-            default="localhost",
+            default=configs["broker_ip"],
             help="Address of the MQTT broker",
         )
         parser.add_argument(
@@ -243,6 +246,7 @@ class Overlay(ABC):
             action="store",
             type=str,
             choices=["v2", "V2", "v3", "V3"],
+            default=configs["bike"],
             help="Specify the which bike to expect MQTT data from",
         )
         parser.add_argument(

--- a/overlay.py
+++ b/overlay.py
@@ -15,8 +15,6 @@ from canvas import Canvas
 from config import read_configs
 from data import Data, DataFactory
 
-DEFAULT_BIKE = "V2"
-
 
 class Overlay(ABC):
     def __init__(self, bike, width=1280, height=740, bg: str = None):
@@ -44,7 +42,7 @@ class Overlay(ABC):
 
         # Bike configuration set up
         configs = read_configs()
-        bike_version = bike or configs["bike"] or DEFAULT_BIKE
+        bike_version = bike or configs["bike"]
         self.data = DataFactory.create(bike_version)
         self.device = configs["device"]
 

--- a/overlay.py
+++ b/overlay.py
@@ -42,8 +42,7 @@ class Overlay(ABC):
 
         # Bike configuration set up
         configs = read_configs()
-        bike_version = bike or configs["bike"]
-        self.data = DataFactory.create(bike_version)
+        self.data = DataFactory.create(bike)
         self.device = configs["device"]
 
         # MQTT client options

--- a/service/install.sh
+++ b/service/install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SERVICE_DIR=$HOME/.config/systemd/user
+RASPICAM_DIR=$(dirname $(cd $(dirname "${BASH_SOURCE[0]}") && pwd))
+
+# Create folder for service if it doesn't yet exist
+mkdir -p $SERVICE_DIR
+# Copy service files to service directory
+cp $RASPICAM_DIR/service/raspicam-orchestrator.service $SERVICE_DIR
+cp $RASPICAM_DIR/service/raspicam-switch.service $SERVICE_DIR
+
+# Append working directory to service file
+echo WorkingDirectory=$RASPICAM_DIR >> $SERVICE_DIR/raspicam-orchestrator.service
+echo WorkingDirectory=$RASPICAM_DIR >> $SERVICE_DIR/raspicam-switch.service

--- a/service/raspicam-orchestrator.service
+++ b/service/raspicam-orchestrator.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=MHP camera system orchestrator
+
+[Install]
+WantedBy=default.target
+
+[Service]
+Environment=PYTHONUNBUFFERED=1
+; Initialise pyenv to use correct python version,
+; then use poetry virtualenv interpreter to run orchestrator.py.
+ExecStart=/bin/bash -c 'eval "$($HOME/.pyenv/bin/pyenv init -)" && $($HOME/.poetry/bin/poetry env info -p)/bin/python orchestrator.py'

--- a/service/raspicam-orchestrator.service
+++ b/service/raspicam-orchestrator.service
@@ -6,6 +6,7 @@ WantedBy=default.target
 
 [Service]
 Environment=PYTHONUNBUFFERED=1
+Restart=on-failure
 ; Initialise pyenv to use correct python version,
 ; then use poetry virtualenv interpreter to run orchestrator.py.
 ExecStart=/bin/bash -c 'eval "$($HOME/.pyenv/bin/pyenv init -)" && $($HOME/.poetry/bin/poetry env info -p)/bin/python orchestrator.py'

--- a/service/raspicam-switch.service
+++ b/service/raspicam-switch.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=MHP camera system switch listener
+
+[Install]
+WantedBy=default.target
+
+[Service]
+Environment=PYTHONUNBUFFERED=1
+; Initialise pyenv to use correct python version,
+; then use poetry virtualenv interpreter to run switch.py.
+ExecStart=/bin/bash -c 'eval "$($HOME/.pyenv/bin/pyenv init -)" && $($HOME/.poetry/bin/poetry env info -p)/bin/python switch.py'

--- a/service/raspicam-switch.service
+++ b/service/raspicam-switch.service
@@ -6,6 +6,7 @@ WantedBy=default.target
 
 [Service]
 Environment=PYTHONUNBUFFERED=1
+Restart=on-failure
 ; Initialise pyenv to use correct python version,
 ; then use poetry virtualenv interpreter to run switch.py.
 ExecStart=/bin/bash -c 'eval "$($HOME/.pyenv/bin/pyenv init -)" && $($HOME/.poetry/bin/poetry env info -p)/bin/python switch.py'

--- a/switch.py
+++ b/switch.py
@@ -5,11 +5,15 @@ from time import sleep
 import RPi.GPIO as gpio
 import config
 
-parser = argparse.ArgumentParser()
+configs = config.read_configs()
+
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
 parser.add_argument(
     "--host",
     type=str,
-    default="192.168.100.100",
+    default=configs["broker_ip"],
     help="ip address of the broker",
 )
 args = parser.parse_args()

--- a/tests/orchestrator_test.py
+++ b/tests/orchestrator_test.py
@@ -1,4 +1,5 @@
 """ Test Script For Orchestrator Class """
+from config import read_configs
 import orchestrator
 
 
@@ -33,7 +34,7 @@ class TestGetArgs:
         Test the arguments parser for the file
         """
         test_input = vars(orchestrator.get_args())
-        expected_result = {"host": "192.168.100.100"}
+        expected_result = {"host": read_configs()["broker_ip"]}
         assert (
             test_input == expected_result
         ), "failed - default ip in function get_args is incorrect"


### PR DESCRIPTION
## Description

Previously, we'd used this hacky file called `rc.local` (not on this repo) to start raspicam automatically. This PR adds stuff to use a `systemd` service instead. `systemd` is a fancy linux thing for managing background services.

This has a few advantages over `rc.local`
- We actually get manual control over the service, allowing us to start/stop the service whenever we like and enable/disable running on startup.
- We can view the output of the services and ensure they're running correctly
- We can make the services automatically restart if they crash (very useful)

Also in this PR, the default broker IP is loaded from the `.env`.

## Screenshots

Orchestrator status looking good
![image](https://user-images.githubusercontent.com/17876556/107897125-75f49580-6f8c-11eb-9968-252fbcc2f543.png)

## Steps to Test

- Get linux or a Pi
- Follow the instructions added in the readme
- Check the services are running correctly with `systemctl --user status raspicam-orchestator`.

If you can't do that, then just have a read through the changes and lmk what you think :)