### PR TITLE
Add battery monitoring and logging toggling

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -30,7 +30,7 @@ import config
 # BCM pin numbering
 logging_button_pin = 4
 
-# See https://github.com/monash-human-power/V3-display-unit-pcb-tests/blob/master/calibrate.py
+# See https://github.com/monash-human-power/V3-display-unit-pcb-tests/blob/72d02c270be413b1d4e97b9d10a33c97f551eafe/calibrate.py # noqa: E501
 battery_calibration_factor = 3.1432999689025483
 battery_publish_interval = 5 * 60  # seconds
 
@@ -105,7 +105,7 @@ class Orchestrator:
     def publish_camera_status(self) -> None:
         """ Send a message on the current device's camera status topic. """
         status_topic = str(topics.Camera.status_camera / self.device)
-        message = dumps({"connected": True, "ip_address": get_ip(),})
+        message = dumps({"connected": True, "ip_address": get_ip()})
         self.mqtt_client.publish(status_topic, message, retain=True)
 
     def battery_loop(self) -> None:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -125,7 +125,8 @@ class Orchestrator:
         client.subscribe(str(topics.Camera.get_overlays))
         client.subscribe(str(topics.WirelessModule.all().module))
         self.publish_camera_status()
-        self.battery_loop()
+        if ON_PI:
+            self.battery_loop()
 
     def on_message(self, client, userdata, msg):
         """The callback for when a PUBLISH message is received."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,56 @@
 [[package]]
+name = "adafruit-blinka"
+version = "6.13.0"
+description = "CircuitPython APIs for non-CircuitPython versions of Python such as CPython on Linux and MicroPython."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[package.dependencies]
+Adafruit-PlatformDetect = ">=3.13.0"
+Adafruit-PureIO = ">=1.1.7"
+pyftdi = ">=0.40.0"
+
+[[package]]
+name = "adafruit-circuitpython-busdevice"
+version = "5.0.6"
+description = "CircuitPython bus device classes to manage bus sharing."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Adafruit-Blinka = "*"
+
+[[package]]
+name = "adafruit-circuitpython-mcp3xxx"
+version = "1.4.5"
+description = "CircuitPython library for the MCP3xxx Analog-to-Digital converters."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Adafruit-Blinka = "*"
+adafruit-circuitpython-busdevice = "*"
+
+[[package]]
+name = "adafruit-platformdetect"
+version = "3.15.3"
+description = "Platform detection for use by libraries like Adafruit-Blinka."
+category = "main"
+optional = false
+python-versions = ">=3.6.0"
+
+[[package]]
+name = "adafruit-pureio"
+version = "1.1.9"
+description = "Pure python (i.e. no native extensions) access to Linux IO    including I2C and SPI. Drop in replacement for smbus and spidev modules."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -318,6 +370,18 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pyftdi"
+version = "0.53.2"
+description = "FTDI device driver (pure Python)"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyserial = ">=3.0"
+pyusb = ">=1.0.0,<1.2.0"
+
+[[package]]
 name = "pylint"
 version = "2.6.2"
 description = "python code static checker"
@@ -339,6 +403,17 @@ description = "Python parsing module"
 category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "pyserial"
+version = "3.5"
+description = "Python Serial Port Extension"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+cp2110 = ["hidapi"]
 
 [[package]]
 name = "pytest"
@@ -384,6 +459,14 @@ python-versions = "*"
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "pyusb"
+version = "1.1.1"
+description = "Python USB access module"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "regex"
@@ -475,9 +558,24 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.7"
-content-hash = "e64bce582ae0957043ae114b68237925e774f5b6539f13356aba1f92af51cbbb"
+content-hash = "730064f74c9209770c872e09552a191c3bcc28c0322b9c8c32e3c4b81aa738a5"
 
 [metadata.files]
+adafruit-blinka = [
+    {file = "Adafruit-Blinka-6.13.0.tar.gz", hash = "sha256:acbcfb778dc5e37ad9ef0aa1e1998e597a99c8a2a08b0dda58c05681950ea1f2"},
+]
+adafruit-circuitpython-busdevice = [
+    {file = "adafruit-circuitpython-busdevice-5.0.6.tar.gz", hash = "sha256:9bb2934e90a151da8b7d9646b25c2ce0b3fd4853f8ba73e8faffedfd8315eda7"},
+]
+adafruit-circuitpython-mcp3xxx = [
+    {file = "adafruit-circuitpython-mcp3xxx-1.4.5.tar.gz", hash = "sha256:67c4bd7ed2b35c1a3620afda5ec8951ecd3b2a33192ac4793f9120425089b315"},
+]
+adafruit-platformdetect = [
+    {file = "Adafruit-PlatformDetect-3.15.3.tar.gz", hash = "sha256:726782879e1dc18c1b2f50301ab3f04c3a7817a54e35c955ee2bb64a6d60df74"},
+]
+adafruit-pureio = [
+    {file = "Adafruit_PureIO-1.1.9.tar.gz", hash = "sha256:2caf22fb07c7f771d83267f331a76cde314723f884a9570ea6f768730c87a879"},
+]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
@@ -736,6 +834,10 @@ pyflakes = [
     {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
     {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
+pyftdi = [
+    {file = "pyftdi-0.53.2-py3-none-any.whl", hash = "sha256:5ba6de65bfc7f9ac9ace145d0a3b5f6f24778a405876bd96a4e361437cc4ce77"},
+    {file = "pyftdi-0.53.2.tar.gz", hash = "sha256:eb88b0583c2ece4f1072ae7951f841f25fb71770833bb53d234c2936adc40841"},
+]
 pylint = [
     {file = "pylint-2.6.2-py3-none-any.whl", hash = "sha256:e71c2e9614a4f06e36498f310027942b0f4f2fde20aebb01655b31edc63b9eaf"},
     {file = "pylint-2.6.2.tar.gz", hash = "sha256:718b74786ea7ed07aa0c58bf572154d4679f960d26e9641cc1de204a30b87fc9"},
@@ -743,6 +845,10 @@ pylint = [
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pyserial = [
+    {file = "pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0"},
+    {file = "pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb"},
 ]
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
@@ -755,6 +861,10 @@ python-dateutil = [
 python-dotenv = [
     {file = "python-dotenv-0.13.0.tar.gz", hash = "sha256:3b9909bc96b0edc6b01586e1eed05e71174ef4e04c71da5786370cebea53ad74"},
     {file = "python_dotenv-0.13.0-py2.py3-none-any.whl", hash = "sha256:25c0ff1a3e12f4bde8d592cc254ab075cfe734fc5dd989036716fd17ee7e5ec7"},
+]
+pyusb = [
+    {file = "pyusb-1.1.1-py3-none-any.whl", hash = "sha256:f18eb813d3a1439918071234589162c2f209a19adbeffeb1377ce078a4aebc70"},
+    {file = "pyusb-1.1.1.tar.gz", hash = "sha256:7d449ad916ce58aff60b89aae0b65ac130f289c24d6a5b7b317742eccffafc38"},
 ]
 regex = [
     {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python-dotenv = "^0.13.0"
 # Raspberry Pi uses the ARM platform, so these will only install on a Pi
 picamera = { version = "^1.13", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 "RPi.GPIO" = { version = "^0.7.0", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
+adafruit-circuitpython-mcp3xxx =  { version = "^1.4.5", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 mhp = {git = "https://github.com/monash-human-power/common.git", rev="202012.9"}
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Description

Two things here.
- Add support for starting and stopping logging using a button attached to BCM pin 4/GPIO pin 7. Configured with an internal pull down resistor, so connect to 3.3V, although this is easily changed. Ideally we'd have a cheeky RC debouncer, but if need be we could probably add software debouncing later. Otherwise I'm getting a lot of bouncing with the button I'm using.
- Battery monitoring. Reports the combined voltage of the two cells (not averaged).

Both of these changes were tested on the V3 display PCB :)

## Screenshots

n/a

## Steps to Test

If you have a raspberry pi on hand it shouldn't be too hard to test the logging button using the description above. Otherwise you'll have to take my word for it, or hack around with the code to manually trigger events.
