### PR TITLE
Reading, Publishing and Display of Voltage

### DIFF
--- a/canvas.py
+++ b/canvas.py
@@ -16,7 +16,7 @@ class Colour(Enum):
     blue = (255, 0, 0, 255)
     green = (0, 255, 0, 255)
     red = (0, 0, 255, 255)
-    yellow = (0,255,255,0)
+    yellow = (0, 255, 255, 0)
 
 
 ColourTuple3 = Tuple[int, int, int]

--- a/canvas.py
+++ b/canvas.py
@@ -16,6 +16,7 @@ class Colour(Enum):
     blue = (255, 0, 0, 255)
     green = (0, 255, 0, 255)
     red = (0, 0, 255, 255)
+    yellow = (0,255,255,0)
 
 
 ColourTuple3 = Tuple[int, int, int]

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -1,6 +1,6 @@
 from .component import Component
 from .transparent_rectangle import TransparentRectangle
-from .data_field import DataField, SpeedField
+from .data_field import DataField, SpeedField,VoltageField
 from .centre_power import CentrePower
 from .message import Message
 from .dashboard_message import DAShboardMessage
@@ -11,6 +11,7 @@ __all__ = [
     "TransparentRectangle",
     "DataField",
     "SpeedField",
+    "VoltageField"
     "CentrePower",
     "Message",
     "DAShboardMessage",

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -1,6 +1,6 @@
 from .component import Component
 from .transparent_rectangle import TransparentRectangle
-from .data_field import DataField, SpeedField,VoltageField
+from .data_field import DataField, SpeedField, VoltageField
 from .centre_power import CentrePower
 from .message import Message
 from .dashboard_message import DAShboardMessage

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -11,7 +11,7 @@ __all__ = [
     "TransparentRectangle",
     "DataField",
     "SpeedField",
-    "VoltageField"
+    "VoltageField",
     "CentrePower",
     "Message",
     "DAShboardMessage",

--- a/components/data_field.py
+++ b/components/data_field.py
@@ -81,3 +81,37 @@ class SpeedField(DataField):
     def draw_data(self, canvas: Canvas, data: Data):
         self.title = "GPS KPH" if data["gps_speed"] else "REED KPH"
         super().draw_data(canvas, data)
+
+# Voltage Class
+class VoltageField(DataField):
+    """A specialised version of DataField which displays the voltage adjusting 
+    for it's values whether the battery is low, medium or high. """
+    
+    def __init__(self, title: str,
+        value_func: Callable[[Data], str],
+        coordinate: Tuple[int, int],
+        is_title_static: bool = True):
+        super().__init__(title, value_func, coordinate, is_title_static)
+        
+    def draw_base(self, canvas: Canvas):
+        return super().draw_base(canvas)
+    
+    def draw_data(self, canvas: Canvas, data: Data):
+        if not self.is_title_static:
+            DataField.draw_base(self, canvas)
+        voltage_value = self.value_func(data)
+        if voltage_value == '--' or float(voltage_value) >= 7.3:
+            colour = Colour.white
+        elif float(voltage_value) >= 7.0:
+            colour = Colour.yellow
+        else:
+            colour = Colour.red
+        canvas.draw_text(
+                voltage_value,
+                self.data_coord,
+                DataField.data_size * 0.7,
+                colour,
+                "right",
+            )
+            
+# TODO VoltageField class -> red when it reaches a threshold

--- a/components/data_field.py
+++ b/components/data_field.py
@@ -83,7 +83,7 @@ class SpeedField(DataField):
 
 
 class VoltageField(DataField):
-    """ A specialised version of DataField which displays the voltage adjusting 
+    """ A specialised version of DataField which displays the voltage adjusting
         for it's values whether the battery is low, medium or high."""
 
     def __init__(self, title: str,

--- a/components/data_field.py
+++ b/components/data_field.py
@@ -86,10 +86,13 @@ class VoltageField(DataField):
     """ A specialised version of DataField which displays the voltage adjusting
         for it's values whether the battery is low, medium or high."""
 
-    def __init__(self, title: str,
-                 value_func: Callable[[Data], str],
-                 coordinate: Tuple[int, int],
-                 is_title_static: bool = True):
+    def __init__(
+        self,
+        title: str,
+        value_func: Callable[[Data], str],
+        coordinate: Tuple[int, int],
+        is_title_static: bool = True,
+    ):
         super().__init__(title, value_func, coordinate, is_title_static)
 
     def draw_base(self, canvas: Canvas):
@@ -99,7 +102,7 @@ class VoltageField(DataField):
         if not self.is_title_static:
             DataField.draw_base(self, canvas)
         voltage_value = self.value_func(data)
-        if voltage_value == '--' or float(voltage_value) >= 7.3:
+        if voltage_value == "--" or float(voltage_value) >= 7.3:
             colour = Colour.white
         elif float(voltage_value) >= 7.0:
             colour = Colour.yellow

--- a/components/data_field.py
+++ b/components/data_field.py
@@ -82,20 +82,20 @@ class SpeedField(DataField):
         self.title = "GPS KPH" if data["gps_speed"] else "REED KPH"
         super().draw_data(canvas, data)
 
-# Voltage Class
+
 class VoltageField(DataField):
     """A specialised version of DataField which displays the voltage adjusting 
     for it's values whether the battery is low, medium or high. """
-    
+
     def __init__(self, title: str,
-        value_func: Callable[[Data], str],
-        coordinate: Tuple[int, int],
-        is_title_static: bool = True):
+                 value_func: Callable[[Data], str],
+                 coordinate: Tuple[int, int],
+                 is_title_static: bool = True):
         super().__init__(title, value_func, coordinate, is_title_static)
-        
+
     def draw_base(self, canvas: Canvas):
         return super().draw_base(canvas)
-    
+
     def draw_data(self, canvas: Canvas, data: Data):
         if not self.is_title_static:
             DataField.draw_base(self, canvas)
@@ -107,11 +107,9 @@ class VoltageField(DataField):
         else:
             colour = Colour.red
         canvas.draw_text(
-                voltage_value,
-                self.data_coord,
-                DataField.data_size * 0.7,
-                colour,
-                "right",
-            )
-            
-# TODO VoltageField class -> red when it reaches a threshold
+            voltage_value,
+            self.data_coord,
+            DataField.data_size * 0.7,
+            colour,
+            "right",
+        )

--- a/components/data_field.py
+++ b/components/data_field.py
@@ -1,5 +1,4 @@
 from typing import Callable, Tuple
-
 from canvas import Canvas, Colour
 from components import Component
 from data import Data
@@ -85,7 +84,7 @@ class SpeedField(DataField):
 
 class VoltageField(DataField):
     """A specialised version of DataField which displays the voltage adjusting 
-    for it's values whether the battery is low, medium or high. """
+    for it's values whether the battery is low, medium or high."""
 
     def __init__(self, title: str,
                  value_func: Callable[[Data], str],

--- a/components/data_field.py
+++ b/components/data_field.py
@@ -83,8 +83,8 @@ class SpeedField(DataField):
 
 
 class VoltageField(DataField):
-    """A specialised version of DataField which displays the voltage adjusting 
-    for it's values whether the battery is low, medium or high."""
+    """ A specialised version of DataField which displays the voltage adjusting 
+        for it's values whether the battery is low, medium or high."""
 
     def __init__(self, title: str,
                  value_func: Callable[[Data], str],

--- a/data.py
+++ b/data.py
@@ -93,7 +93,7 @@ class Data(ABC):
             "zdist": DataValue(float),
             "plan_name": DataValue(str),
             # Voltage
-            "voltage" : DataValue(float)
+            "voltage": DataValue(float)
         }
         self.message = DataValue(str, 20)
 

--- a/data.py
+++ b/data.py
@@ -245,12 +245,12 @@ class DataV3(Data):
                 self.data["reed_distance"].update(sensor_value)
             elif sensor_name in self.data.keys():
                 self.data[sensor_name].update(sensor_value)
-                
+
     def load_voltage_data(self, data: str) -> None:
-        voltage_data = loads('{"voltage":1}')
+        voltage_data = loads('{"voltage":4.3123}')
         # voltage_data = loads(data)
         self.data["voltage"].update(voltage_data["voltage"])
-        
+
     def load_recommended_sp(self, data: str) -> None:
         python_data = loads(data)
         self.data["rec_power"].update(python_data["power"])

--- a/data.py
+++ b/data.py
@@ -92,6 +92,8 @@ class Data(ABC):
             "predicted_max_speed": DataValue(float),
             "zdist": DataValue(float),
             "plan_name": DataValue(str),
+            # Voltage
+            "voltage" : DataValue(float)
         }
         self.message = DataValue(str, 20)
 

--- a/data.py
+++ b/data.py
@@ -214,7 +214,7 @@ class DataV3(Data):
         device = config.read_configs()["device"]
         battery_topic = topics.Camera.status_camera/device/"battery"
         return battery_topic
-    
+
     def load_data(self, topic: str, data: str) -> None:
         """Update stored fields with data from a V3 sensor module data packet.
         """
@@ -251,7 +251,7 @@ class DataV3(Data):
                 self.data["reed_distance"].update(sensor_value)
             elif sensor_name in self.data.keys():
                 self.data[sensor_name].update(sensor_value)
-    
+
     def load_voltage_data(self, data: str) -> None:
         # voltage_data = loads(data)
         voltage_data = loads('{"voltage":7.1312}')

--- a/data.py
+++ b/data.py
@@ -93,7 +93,7 @@ class Data(ABC):
             "zdist": DataValue(float),
             "plan_name": DataValue(str),
             # Voltage
-            "voltage": DataValue(float)
+            "voltage": DataValue(float),
         }
         self.message = DataValue(str, 20)
 
@@ -196,7 +196,6 @@ class DataV2(Data):
 
 
 class DataV3(Data):
-
     @staticmethod
     def get_topics() -> List[topics.Topic]:
         # TODO: Not have to read configs everytime
@@ -212,7 +211,7 @@ class DataV3(Data):
     @staticmethod
     def create_voltage_topic() -> topics.Topic:
         device = config.read_configs()["device"]
-        battery_topic = topics.Camera.status_camera/device/"battery"
+        battery_topic = topics.Camera.status_camera / device / "battery"
         return battery_topic
 
     def load_data(self, topic: str, data: str) -> None:

--- a/data.py
+++ b/data.py
@@ -247,8 +247,7 @@ class DataV3(Data):
                 self.data[sensor_name].update(sensor_value)
 
     def load_voltage_data(self, data: str) -> None:
-        voltage_data = loads('{"voltage":4.3123}')
-        # voltage_data = loads(data)
+        voltage_data = loads(data)
         self.data["voltage"].update(voltage_data["voltage"])
 
     def load_recommended_sp(self, data: str) -> None:

--- a/data.py
+++ b/data.py
@@ -196,21 +196,21 @@ class DataV2(Data):
 
 
 class DataV3(Data):
+
     @staticmethod
-    def get_topics(self) -> List[topics.Topic]:
+    def get_topics() -> List[topics.Topic]:
         # TODO: Not have to read configs everytime
         return [
             topics.WirelessModule.all().data,
             topics.Camera.overlay_message,
-            self.create_voltage_topic(),
-            # TODO: BOOST currently publishes data in the deprecated V2 format
-            # on the V3 topic. Uncomment below when updated.
-            # topics.BOOST.recommended_sp,
-            # topics.BOOST.predicted_max_speed,
+            DataV3.create_voltage_topic(),
+            topics.BOOST.recommended_sp,
+            topics.BOOST.predicted_max_speed,
             # TODO: Implement handling topics.BOOST.generate_complete
         ]
 
-    def create_voltage_topic(self):
+    @staticmethod
+    def create_voltage_topic() -> topics.Topic:
         device = config.read_configs()["device"]
         battery_topic = topics.Camera.status_camera/device/"battery"
         return battery_topic
@@ -253,8 +253,7 @@ class DataV3(Data):
                 self.data[sensor_name].update(sensor_value)
 
     def load_voltage_data(self, data: str) -> None:
-        # voltage_data = loads(data)
-        voltage_data = loads('{"voltage":7.1312}')
+        voltage_data = loads(data)
         self.data["voltage"].update(voltage_data["voltage"])
 
     def load_recommended_sp(self, data: str) -> None:

--- a/data.py
+++ b/data.py
@@ -201,6 +201,7 @@ class DataV3(Data):
         return [
             topics.WirelessModule.all().data,
             topics.Camera.overlay_message,
+            topics.WirelessModule.all().battery
             # TODO: BOOST currently publishes data in the deprecated V2 format
             # on the V3 topic. Uncomment below when updated.
             # topics.BOOST.recommended_sp,
@@ -215,6 +216,8 @@ class DataV3(Data):
             self.load_message_json(data)
         elif topics.WirelessModule.all().data.matches(topic):
             self.load_sensor_data(data)
+        elif topics.WirelessModule.all().battery.matches(topic):
+            self.load_voltage_data(data)
         elif topic == topics.BOOST.recommended_sp:
             self.load_recommended_sp(data)
         elif topic == topics.BOOST.predicted_max_speed:
@@ -229,7 +232,6 @@ class DataV3(Data):
         """Load data in the json V3 wireless sensor module format."""
         module_data = loads(data)
         sensor_data = module_data["sensors"]
-
         for sensor in sensor_data:
             sensor_name = sensor["type"]
             sensor_value = sensor["value"]
@@ -243,7 +245,12 @@ class DataV3(Data):
                 self.data["reed_distance"].update(sensor_value)
             elif sensor_name in self.data.keys():
                 self.data[sensor_name].update(sensor_value)
-
+                
+    def load_voltage_data(self, data: str) -> None:
+        voltage_data = loads('{"voltage":1}')
+        # voltage_data = loads(data)
+        self.data["voltage"].update(voltage_data["voltage"])
+        
     def load_recommended_sp(self, data: str) -> None:
         python_data = loads(data)
         self.data["rec_power"].update(python_data["power"])

--- a/data.py
+++ b/data.py
@@ -253,8 +253,7 @@ class DataV3(Data):
                 self.data[sensor_name].update(sensor_value)
 
     def load_voltage_data(self, data: str) -> None:
-        # voltage_data = loads(data)
-        voltage_data = loads('{"voltage":7.12321}')
+        voltage_data = loads(data)
         self.data["voltage"].update(voltage_data["voltage"])
 
     def load_recommended_sp(self, data: str) -> None:

--- a/data.py
+++ b/data.py
@@ -199,7 +199,8 @@ class DataV3(Data):
     @staticmethod
     def get_topics() -> List[topics.Topic]:
         device = config.read_configs()["device"]
-        battery_topic = topics.Camera.status_camera.__truediv__(device).__truediv__("battery")
+        battery_topic = topics.Camera.status_camera.__truediv__(
+            device).__truediv__("battery")
         return [
             topics.WirelessModule.all().data,
             topics.Camera.overlay_message,
@@ -215,7 +216,8 @@ class DataV3(Data):
         """Update stored fields with data from a V3 sensor module data packet.
         """
         device = config.read_configs()["device"]
-        battery_topic = topics.Camera.status_camera.__truediv__(device).__truediv__("battery")
+        battery_topic = topics.Camera.status_camera.__truediv__(
+            device).__truediv__("battery")
         if topic == topics.Camera.overlay_message:
             self.load_message_json(data)
         elif topics.WirelessModule.all().data.matches(topic):

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -89,7 +89,7 @@ class OverlayNew(Overlay):
             CentrePower(self.width, self.height),
             DAShboardMessage(),
             DASDisconnectMessage(self.client),
-            
+
         ]
 
     def _draw_base_layer(self):

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -45,6 +45,7 @@ class OverlayNew(Overlay):
             (col_coords[2], row_coords[0] - DataField.height - spacing),
             (self.width, self.height),
         ]
+
         # Dimensions of the top right Transparent rectangle
         top_right_rect = [
             (col_coords[3] + spacing, 0),
@@ -86,7 +87,6 @@ class OverlayNew(Overlay):
             ),
             DataField(
                 "VOLTAGE",
-                # voltage to 1 decimal place
                 self.get_data_func("voltage", 1),
                 data_field_coord(3, 2),
             ),

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -22,7 +22,7 @@ class OverlayNew(Overlay):
             self.height - (2 * spacing + DataField.height),
             self.height - spacing,
             # top right position for voltage
-            (spacing + DataField.height)
+            (spacing + DataField.height),
         ]
         col_coords = [
             spacing,
@@ -50,7 +50,7 @@ class OverlayNew(Overlay):
         # Dimensions of the top right Transparent rectangle
         top_right_rect = [
             (col_coords[3] + spacing, 0),
-            (self.width, DataField.height + 2*spacing)
+            (self.width, DataField.height + 2 * spacing),
         ]
         # Create all overlay components
         self.components = [

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -2,6 +2,7 @@ from components import (
     TransparentRectangle,
     DataField,
     SpeedField,
+    VoltageField,
     CentrePower,
     DAShboardMessage,
     DASDisconnectMessage,
@@ -49,7 +50,7 @@ class OverlayNew(Overlay):
         # Dimensions of the top right Transparent rectangle
         top_right_rect = [
             (col_coords[3] + spacing, 0),
-            (self.width, DataField.height + spacing)
+            (self.width, DataField.height + 2*spacing)
         ]
         # Create all overlay components
         self.components = [
@@ -85,9 +86,10 @@ class OverlayNew(Overlay):
                 self.get_data_func("reed_distance", 2, 0.001),
                 data_field_coord(3, 1),
             ),
-            DataField(
+            VoltageField(
+                # should change colour at 3.5V
                 "VOLTAGE",
-                self.get_data_func("voltage", 1),
+                self.get_data_func("voltage", 2),
                 data_field_coord(3, 2),
             ),
             CentrePower(self.width, self.height),

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -29,7 +29,6 @@ class OverlayNew(Overlay):
             self.width - 2 * (spacing + DataField.width),
             self.width - (spacing + DataField.width),
         ]
-        # testing commenting and gitr pushing
 
         def data_field_coord(x, y):
             """Coordinates of the data field in column x, row y."""

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -29,6 +29,7 @@ class OverlayNew(Overlay):
             self.width - 2 * (spacing + DataField.width),
             self.width - (spacing + DataField.width),
         ]
+        # testing commenting and gitr pushing
 
         def data_field_coord(x, y):
             """Coordinates of the data field in column x, row y."""

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -20,7 +20,8 @@ class OverlayNew(Overlay):
         row_coords = [
             self.height - (2 * spacing + DataField.height),
             self.height - spacing,
-            # this coordinates are for the voltage, need advice for voltage position later
+            # this coordinates are for the voltage, 
+            # need advice for voltage position later
             self.height - (6 * spacing + DataField.height)
         ]
         col_coords = [
@@ -89,7 +90,6 @@ class OverlayNew(Overlay):
             CentrePower(self.width, self.height),
             DAShboardMessage(),
             DASDisconnectMessage(self.client),
-
         ]
 
     def _draw_base_layer(self):

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -87,7 +87,6 @@ class OverlayNew(Overlay):
                 data_field_coord(3, 1),
             ),
             VoltageField(
-                # should change colour at 3.5V
                 "VOLTAGE",
                 self.get_data_func("voltage", 2),
                 data_field_coord(3, 2),

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -48,14 +48,13 @@ class OverlayNew(Overlay):
         # Dimensions of the top right Transparent rectangle
         top_right_rect = [
             (col_coords[3] + spacing, 0),
-            (self.width, row_coords[2])
+            (self.width, DataField.height + spacing)
         ]
-        print(self.height)
-        print(self.width)
         # Create all overlay components
         self.components = [
             TransparentRectangle(*left_rect),
             TransparentRectangle(*right_rect),
+            # rectangle for voltage
             TransparentRectangle(*top_right_rect),
             DataField(
                 "RPM", self.get_data_func("cadence"), data_field_coord(0, 0)

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -20,6 +20,8 @@ class OverlayNew(Overlay):
         row_coords = [
             self.height - (2 * spacing + DataField.height),
             self.height - spacing,
+            # this coordinates are for the voltage, need advice for voltage position later
+            self.height - (6 * spacing + DataField.height)
         ]
         col_coords = [
             spacing,
@@ -43,7 +45,8 @@ class OverlayNew(Overlay):
             (col_coords[2], row_coords[0] - DataField.height - spacing),
             (self.width, self.height),
         ]
-
+        print(self.height)
+        print(self.width)
         # Create all overlay components
         self.components = [
             TransparentRectangle(*left_rect),
@@ -76,9 +79,17 @@ class OverlayNew(Overlay):
                 self.get_data_func("reed_distance", 2, 0.001),
                 data_field_coord(3, 1),
             ),
+            # TODO voltage configs?
+            DataField(
+                "VOLTAGE",
+                # voltage to 1 decimal place
+                self.get_data_func("voltage", 1),
+                data_field_coord(3, 2),
+            ),
             CentrePower(self.width, self.height),
             DAShboardMessage(),
             DASDisconnectMessage(self.client),
+            
         ]
 
     def _draw_base_layer(self):

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -20,9 +20,8 @@ class OverlayNew(Overlay):
         row_coords = [
             self.height - (2 * spacing + DataField.height),
             self.height - spacing,
-            # this coordinates are for the voltage,
-            # need advice for voltage position later
-            self.height - (6 * spacing + DataField.height)
+            # top right position for voltage
+            (spacing + DataField.height)
         ]
         col_coords = [
             spacing,
@@ -46,12 +45,18 @@ class OverlayNew(Overlay):
             (col_coords[2], row_coords[0] - DataField.height - spacing),
             (self.width, self.height),
         ]
+        # Dimensions of the top right Transparent rectangle
+        top_right_rect = [
+            (col_coords[3] + spacing, 0),
+            (self.width, row_coords[2])
+        ]
         print(self.height)
         print(self.width)
         # Create all overlay components
         self.components = [
             TransparentRectangle(*left_rect),
             TransparentRectangle(*right_rect),
+            TransparentRectangle(*top_right_rect),
             DataField(
                 "RPM", self.get_data_func("cadence"), data_field_coord(0, 0)
             ),
@@ -80,7 +85,6 @@ class OverlayNew(Overlay):
                 self.get_data_func("reed_distance", 2, 0.001),
                 data_field_coord(3, 1),
             ),
-            # TODO voltage configs?
             DataField(
                 "VOLTAGE",
                 # voltage to 1 decimal place

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -20,7 +20,7 @@ class OverlayNew(Overlay):
         row_coords = [
             self.height - (2 * spacing + DataField.height),
             self.height - spacing,
-            # this coordinates are for the voltage, 
+            # this coordinates are for the voltage,
             # need advice for voltage position later
             self.height - (6 * spacing + DataField.height)
         ]


### PR DESCRIPTION
## Description

Enables display of the voltage on the top right of the camera. Also added the reading and publishing of battery onto the screen.

## Screenshots

![image](https://user-images.githubusercontent.com/78238077/128469947-30b45945-4b3b-45cb-9ee4-71f21036a4b6.png)
![image](https://user-images.githubusercontent.com/78238077/128470308-a724a892-db8f-4a32-ab35-84bad8be61cd.png)
![image](https://user-images.githubusercontent.com/78238077/130418455-7423ca3d-0d7e-4a76-a1b6-bf496aaf1b82.png)
![image](https://user-images.githubusercontent.com/78238077/129316141-2c6421fd-c051-401e-95af-0a3439e8da88.png)
![image](https://user-images.githubusercontent.com/78238077/129316094-3bd6dc07-f865-4795-9a33-b1058c3b9c86.png)

## Steps to Test

1. Run the poetry shell, poetry install
2. Replace `voltage_data = loads(data)` in the image above with `voltage_data = loads('{"voltage":6.5312}')` for red text, `voltage_data = loads('{"voltage":7.132}')`  for yellow text, `voltage_data = loads('{"voltage":7.34123}')` for white text 
3. Run `python overlay_new.py --host localhost` in the poetry shell. You should see voltage on the top right corner of the screen
4. Run `mosquitto_pub -t "status/camera/primary/battery" -h localhost -m "(any message)"`
5. For a couple of seconds you should see the voltage appear in the top right