### PR TITLE
Improve raspicam switches and LEDs

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -9,7 +9,7 @@ from threading import Timer
 import paho.mqtt.client as mqtt
 
 try:
-    from utils.hardware import LED, Switch
+    from utils.hardware import LED, cleanup
     import adafruit_mcp3xxx.mcp3004 as MCP
     import board
     import busio
@@ -193,4 +193,4 @@ if __name__ == "__main__":
         orchestrator.start()
     finally:
         if ON_PI:
-            gpio.cleanup()
+            cleanup()

--- a/switch.py
+++ b/switch.py
@@ -3,7 +3,7 @@ import asyncio
 import subprocess
 
 import config
-from utils.hardware import LED, Switch, use_board_pins
+from utils.hardware import LED, Switch, use_board_pins, cleanup
 
 switch_on_state = True
 
@@ -82,7 +82,7 @@ async def main():
     except KeyboardInterrupt:
         if overlay_process:
             subprocess.Popen.kill(overlay_process)
-        gpio.cleanup()
+        cleanup()
 
 
 if __name__ == "__main__":

--- a/switch.py
+++ b/switch.py
@@ -20,25 +20,34 @@ args = parser.parse_args()
 
 brokerIP = args.host
 
-# Pins
-switch = 15
-green_led = 11
-red_led = 13
-
 gpio.setmode(gpio.BOARD)
 gpio.setwarnings(False)
 
-gpio.setup(switch, gpio.IN, pull_up_down=gpio.PUD_UP)  # toggle switch
-gpio.setup(green_led, gpio.OUT)  # green LED
-gpio.setup(red_led, gpio.OUT)
+
+class Switch:
+    def __init__(self, pin):
+        self.pin = pin
+        gpio.setup(pin, gpio.IN, pull_up_down=gpio.PUD_UP)
+
+    def read(self):
+        return gpio.input(self.pin)
 
 
-def turn_on(led):
-    gpio.output(led, gpio.HIGH)
+class LED:
+    def __init__(self, pin):
+        self.pin = pin
+        gpio.setup(pin, gpio.OUT)
+
+    def turn_on(self):
+        gpio.output(self.pin, gpio.HIGH)
+
+    def turn_off(self):
+        gpio.output(self.pin, gpio.LOW)
 
 
-def turn_off(led):
-    gpio.output(led, gpio.LOW)
+switch = Switch(15)
+green_led = LED(11)
+red_led = LED(13)
 
 
 virtualenv_dir = (
@@ -50,10 +59,10 @@ print("env dir:", virtualenv_dir)
 
 try:
     while True:
-        prev_switch_state = gpio.input(15)
+        prev_switch_state = switch.read()
         while True:
-            turn_on(red_led)
-            switch_state = gpio.input(15)
+            red_led.turn_on()
+            switch_state = switch.read()
             if switch_state == prev_switch_state:
                 print("OFF")
             else:
@@ -70,16 +79,16 @@ try:
                 brokerIP,
             ]
         )
-        turn_off(red_led)
-        turn_on(green_led)
+        red_led.turn_off()
+        green_led.turn_on()
         sleep(1)
 
         while True:
-            switch_state = gpio.input(15)
+            switch_state = switch.read()
             if switch_state != prev_switch_state:
                 print("OFF")
                 subprocess.Popen.kill(p1)
-                turn_off(green_led)
+                green_led.turn_off()
                 break
             else:
                 print("ON")

--- a/switch.py
+++ b/switch.py
@@ -2,10 +2,9 @@ import argparse
 import asyncio
 import subprocess
 
-import RPi.GPIO as gpio
 import config
+from utils.hardware import LED, Switch, use_board_pins
 
-poll_frequency = 0.5
 switch_on_state = True
 
 configs = config.read_configs()
@@ -23,36 +22,7 @@ args = parser.parse_args()
 
 brokerIP = args.host
 
-gpio.setmode(gpio.BOARD)
-gpio.setwarnings(False)
-
-
-class Switch:
-    def __init__(self, pin):
-        self.pin = pin
-        gpio.setup(pin, gpio.IN, pull_up_down=gpio.PUD_UP)
-
-    def read(self):
-        return gpio.input(self.pin)
-
-    async def wait_for_state(self, state):
-        while True:
-            if self.read() == state:
-                return
-            await asyncio.sleep(poll_frequency)
-
-
-class LED:
-    def __init__(self, pin):
-        self.pin = pin
-        gpio.setup(pin, gpio.OUT)
-
-    def turn_on(self):
-        gpio.output(self.pin, gpio.HIGH)
-
-    def turn_off(self):
-        gpio.output(self.pin, gpio.LOW)
-
+use_board_pins()
 
 switch = Switch(15)
 green_led = LED(11)
@@ -94,9 +64,6 @@ async def main():
                     brokerIP,
                 ]
             )
-
-            red_led.turn_on()
-            green_led.turn_off()
 
     except KeyboardInterrupt:
         if overlay_process:

--- a/utils/hardware.py
+++ b/utils/hardware.py
@@ -13,6 +13,10 @@ def use_board_pins():
     gpio.setmode(gpio.BOARD)
 
 
+def cleanup():
+    gpio.cleanup()
+
+
 class Switch:
     def __init__(self, pin):
         self.pin = pin

--- a/utils/hardware.py
+++ b/utils/hardware.py
@@ -1,0 +1,40 @@
+import asyncio
+import RPi.GPIO as gpio
+
+
+poll_frequency = 0.5
+
+
+# Ignore warnings about multiple scripts playing with GPIO
+gpio.setwarnings(False)
+
+
+def use_board_pins():
+    gpio.setmode(gpio.BOARD)
+
+
+class Switch:
+    def __init__(self, pin):
+        self.pin = pin
+        gpio.setup(pin, gpio.IN, pull_up_down=gpio.PUD_UP)
+
+    def read(self):
+        return gpio.input(self.pin)
+
+    async def wait_for_state(self, state):
+        while True:
+            if self.read() == state:
+                return
+            await asyncio.sleep(poll_frequency)
+
+
+class LED:
+    def __init__(self, pin):
+        self.pin = pin
+        gpio.setup(pin, gpio.OUT)
+
+    def turn_on(self):
+        gpio.output(self.pin, gpio.HIGH)
+
+    def turn_off(self):
+        gpio.output(self.pin, gpio.LOW)


### PR DESCRIPTION
## Description

- Video feed toggle now has absolute switch positions i.e. the on position is always the same direction, not just defined as the opposite as the power up direction
- Refactored a lot of hardware-related code
- Utilised the 3rd (orange) led on the display to show when orchestrator is connected to the MQTT broker.

To summarise the meanings of the LEDs, there is a red and green led, of which only one is ever turned on. Green means video is turned on, otherwise red means it's off. The orange LED is turned on when connected to the MQTT broker.

## Screenshots

![image](https://user-images.githubusercontent.com/17876556/152665391-bcc2d625-b157-4a4c-b53d-e15216a6b6cf.png)

## Steps to Test

Acquire a display unit. Set up the systemd services, make sure the broker in the `.env` is accessible. Restart. Some time after boot, the orange LED should turn on. Depending on the switch state, one of the other two will also be on. Flicking the switch should toggle video and toggle which of the red/green LEDs are on.
