### PR TITLE
Fix secondary display logging button

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -27,7 +27,7 @@ import config
 
 
 # BCM pin numbering
-logging_button_pin = 4
+logging_button_pin = 5 # Board pin 29
 
 # See https://github.com/monash-human-power/V3-display-unit-pcb-tests/blob/72d02c270be413b1d4e97b9d10a33c97f551eafe/calibrate.py # noqa: E501
 battery_calibration_factor = 3.1432999689025483

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -98,6 +98,7 @@ class Orchestrator:
         for module in modules:
             topic = module.stop if self.currently_logging else module.start
             self.mqtt_client.publish(str(topic))
+        self.mqtt_client.publish(topics.BOOST.start)
         # `self.currently_logging` will be updated when we receive the message
         # we publish above.
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -91,7 +91,7 @@ class Orchestrator:
     def get_battery_voltage(self) -> float:
         return self.battery_adc.voltage * battery_calibration_factor
 
-    def toggle_logging(self) -> None:
+    def toggle_logging(self, _) -> None:
         modules = [topics.WirelessModule.id(i) for i in range(1, 5)]
         for module in modules:
             topic = module.stop if self.currently_logging else module.start

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -27,7 +27,7 @@ import config
 
 
 # BCM pin numbering
-logging_button_pin = 5 # Board pin 29
+logging_button_pin = 5  # Board pin 29
 
 # See https://github.com/monash-human-power/V3-display-unit-pcb-tests/blob/72d02c270be413b1d4e97b9d10a33c97f551eafe/calibrate.py # noqa: E501
 battery_calibration_factor = 3.1432999689025483

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -103,7 +103,10 @@ class Orchestrator:
         """Set the data logging state of the camera, updating the LED."""
         self.currently_logging = logging
         if ON_PI:
-            self.logging_led.turn_on() if logging else self.logging_led.turn_off()
+            if logging:
+                self.logging_led.turn_on()
+            else:
+                self.logging_led.turn_off()
 
     def publish_camera_status(self) -> None:
         """Send a message on the current device's camera status topic."""

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -153,10 +153,10 @@ class Orchestrator:
             self.set_logging_state(True)
         elif topics.WirelessModule.all().data.matches(msg.topic):
             self.data_messages_received += 1
-            # We have 4 WMs, so in the worst case we shouldn't receive more
+            # We have 3 WMs, so in the worst case we shouldn't receive more
             # than four messages due to delay after logging stops. If we do,
             # we know we missed the start message.
-            if not self.currently_logging and self.data_messages_received > 4:
+            if not self.currently_logging and self.data_messages_received > 3:
                 self.set_logging_state(True)
         elif topics.WirelessModule.all().stop.matches(msg.topic):
             self.set_logging_state(False)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -87,8 +87,8 @@ class Orchestrator:
             self.battery_adc = AnalogIn(mcp, MCP.P0)
 
             # BCM pin numbering
-            self.connected_led = LED(18)  # Board pin 24
-            self.logging_led = LED(27)  # Board pin 13
+            self.connected_led = LED(18)  # Board pin 24, yellow led
+            self.logging_led = LED(27)  # Board pin 13, red led
 
     def get_battery_voltage(self) -> float:
         return self.battery_adc.voltage * battery_calibration_factor

--- a/switch.py
+++ b/switch.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import subprocess
+import sys
 
 import config
 from utils.hardware import LED, Switch, use_board_pins, cleanup
@@ -29,13 +30,6 @@ green_led = LED(11)
 red_led = LED(13)
 
 
-virtualenv_dir = (
-    subprocess.check_output(["poetry", "env", "info", "-p"])
-    .decode("utf-8")
-    .strip()
-)
-print("env dir:", virtualenv_dir)
-
 overlay_process = None
 
 
@@ -48,7 +42,7 @@ def enable():
     global overlay_process
     overlay_process = subprocess.Popen(
         [
-            f"{virtualenv_dir}/bin/python",
+            sys.executable,
             config.get_active_overlay(),
             "--host",
             brokerIP,

--- a/switch.py
+++ b/switch.py
@@ -41,12 +41,7 @@ def enable():
 
     global overlay_process
     overlay_process = subprocess.Popen(
-        [
-            sys.executable,
-            config.get_active_overlay(),
-            "--host",
-            brokerIP,
-        ]
+        [sys.executable, config.get_active_overlay(), "--host", brokerIP]
     )
 
 

--- a/switch.py
+++ b/switch.py
@@ -27,7 +27,6 @@ use_board_pins()
 
 switch = Switch(15)
 green_led = LED(11)
-red_led = LED(13)
 
 
 overlay_process = None
@@ -36,8 +35,7 @@ overlay_process = None
 def enable():
     print("ON")
 
-    red_led.turn_off()
-    green_led.turn_on()
+    green_led.turn_off()
 
     global overlay_process
     overlay_process = subprocess.Popen(
@@ -48,8 +46,7 @@ def enable():
 def disable():
     print("OFF")
 
-    red_led.turn_on()
-    green_led.turn_off()
+    green_led.turn_on()
 
     global overlay_process
     if overlay_process:

--- a/utils/hardware.py
+++ b/utils/hardware.py
@@ -18,9 +18,9 @@ def cleanup():
 
 
 class Switch:
-    def __init__(self, pin):
+    def __init__(self, pin, pull_up_down=gpio.PUD_UP):
         self.pin = pin
-        gpio.setup(pin, gpio.IN, pull_up_down=gpio.PUD_UP)
+        gpio.setup(pin, gpio.IN, pull_up_down=pull_up_down)
 
     def read(self):
         return gpio.input(self.pin)

--- a/utils/hardware.py
+++ b/utils/hardware.py
@@ -31,7 +31,7 @@ class Switch:
                 return
             await asyncio.sleep(poll_frequency)
 
-    def create_interrupt(self, callback, bouncetime=0.5):
+    def create_interrupt(self, callback, bouncetime=500):
         gpio.add_event_detect(
             self.pin, gpio.RISING, callback=callback, bouncetime=bouncetime
         )

--- a/utils/hardware.py
+++ b/utils/hardware.py
@@ -1,6 +1,5 @@
 import asyncio
 import RPi.GPIO as gpio
-import time
 
 
 poll_frequency = 0.5
@@ -21,8 +20,6 @@ def cleanup():
 class Switch:
     def __init__(self, pin, pull_up_down=gpio.PUD_UP):
         self.pin = pin
-        self.last_interrupt_time = time.time()
-        self.debounce_period = 0.5
         gpio.setup(pin, gpio.IN, pull_up_down=pull_up_down)
 
     def read(self):
@@ -34,17 +31,9 @@ class Switch:
                 return
             await asyncio.sleep(poll_frequency)
 
-    def _interrupt_callback(self, _pin_number):
-        time_since_interrupt = time.time() - self.last_interrupt_time
-        self.last_interrupt_time = time.time()
-        if self.debounce and time_since_interrupt > self.debounce_period:
-            self.callback()
-
-    def create_interrupt(self, callback, debounce=True):
-        self.callback = callback
-        self.debounce = debounce
+    def create_interrupt(self, callback, bouncetime=0.5):
         gpio.add_event_detect(
-            self.pin, gpio.RISING, callback=self._interrupt_callback
+            self.pin, gpio.RISING, callback=callback, bouncetime=bouncetime
         )
 
 

--- a/utils/hardware.py
+++ b/utils/hardware.py
@@ -43,7 +43,9 @@ class Switch:
     def create_interrupt(self, callback, debounce=True):
         self.callback = callback
         self.debounce = debounce
-        gpio.add_event_detect(self.pin, gpio.RISING, callback=self._interrupt_callback)
+        gpio.add_event_detect(
+            self.pin, gpio.RISING, callback=self._interrupt_callback
+        )
 
 
 class LED:


### PR DESCRIPTION
## Description

A few fixes here, mainly with the logging button
- Corrected the pin for the logging button and correctly set up the internal pull-down resistor
- Added debouncing to this switch (otherwise we'd get 3ish triggers per press/release)
- Improved how we find the interpreter to launch camera overlays with (the poetry method wasn't always reliable)

## Screenshots

n/a

## Steps to Test

Will demo in tonight's meeting! Grab the secondary, turn on, connect to broker, subscribe to a start topic and press the button. You should see start/stop published.
