### PR TITLE
Rider dev overlay tweaks: round 2

### DIFF
--- a/backend/picamera_backend.py
+++ b/backend/picamera_backend.py
@@ -84,7 +84,7 @@ class PiCameraBackend(Backend):
         If the overlay was already added, removes the old instance.
         """
         overlay = self.pi_camera.add_overlay(
-            canvas.img, format="rgba", size=(self.width, self.height)
+            canvas.img, format="bgra", size=(self.width, self.height)
         )
         overlay.layer = layer.value
         overlay.fullscreen = False

--- a/canvas.py
+++ b/canvas.py
@@ -123,6 +123,17 @@ class Canvas:
             self.img, top_left, bottom_right, colour, thickness=cv2.FILLED
         )
 
+    def draw_circle(
+        self, center: Coord, radius: float, colour: Colourlike = Colour.black,
+    ) -> None:
+        """Draws a circle to the canvas.
+
+        center is a tuple, and specifies the dimensions of the circle (the top
+        left of the screen is the origin).
+        """
+        colour = Canvas._get_colour_tuple(colour)
+        cv2.circle(self.img, center, radius, colour, thickness=cv2.FILLED)
+
     def copy_to(self, dest: np.ndarray) -> np.ndarray:
         """Writes the contents of self.img over dest.
 

--- a/components/__init__.py
+++ b/components/__init__.py
@@ -5,6 +5,7 @@ from .centre_power import CentrePower
 from .message import Message
 from .dashboard_message import DAShboardMessage
 from .das_disconnect_message import DASDisconnectMessage
+from .logging_indicator import LoggingIndicator
 
 __all__ = [
     "Component",
@@ -16,4 +17,5 @@ __all__ = [
     "Message",
     "DAShboardMessage",
     "DASDisconnectMessage",
+    "LoggingIndicator",
 ]

--- a/components/centre_power.py
+++ b/components/centre_power.py
@@ -43,7 +43,7 @@ class CentrePower(Component):
             rec_power_str = "--"
 
         if rec_power == 0 or rec_power is None or power is None:
-            rec_power_colour = Colour.black
+            rec_power_colour = Colour.white
         else:
             power_diff = abs(power / rec_power - 1)
             # Colour.green is too light against the white fairing
@@ -58,7 +58,7 @@ class CentrePower(Component):
             power_str,
             self.power_coord,
             CentrePower.power_size,
-            Colour.red,
+            Colour.white,
             "centre",
         )
         canvas.draw_text(

--- a/components/logging_indicator.py
+++ b/components/logging_indicator.py
@@ -1,0 +1,21 @@
+from components import Component
+from canvas import Canvas, Colour, Coord
+from data import Data
+
+
+class LoggingIndicator(Component):
+    """A red circle to symbolise DAS logging"""
+
+    COLOUR = Colour.red
+    RADIUS = 10
+
+    def __init__(self, center: Coord):
+        self.center = center
+
+    def draw_base(self, canvas: Canvas):
+        canvas.draw_circle(
+            self.center, LoggingIndicator.RADIUS, LoggingIndicator.COLOUR
+        )
+
+    def draw_data(self, canvas: Canvas, data: Data):
+        pass

--- a/components/logging_indicator.py
+++ b/components/logging_indicator.py
@@ -13,9 +13,10 @@ class LoggingIndicator(Component):
         self.center = center
 
     def draw_base(self, canvas: Canvas):
-        canvas.draw_circle(
-            self.center, LoggingIndicator.RADIUS, LoggingIndicator.COLOUR
-        )
+        pass
 
     def draw_data(self, canvas: Canvas, data: Data):
-        pass
+        if data.is_logging():
+            canvas.draw_circle(
+                self.center, LoggingIndicator.RADIUS, LoggingIndicator.COLOUR
+            )

--- a/data.py
+++ b/data.py
@@ -43,6 +43,9 @@ class DataValue:
         if self.data_type is str:
             return self.get()
 
+        if self.data_type is bool:
+            return str(self.get())
+
         if self.is_valid():
             format_str = f"{{:.{decimals}f}}"
             return format_str.format(self.value * scalar)
@@ -95,7 +98,16 @@ class Data(ABC):
             # Voltage
             "voltage": DataValue(float, config.BATTERY_PUBLISH_INTERVAL),
         }
+        self.logging = DataValue(bool, time_to_expire=3600)
         self.message = DataValue(str, 20)
+
+    def set_logging(self, logging: bool) -> None:
+        """Set the logging status of the DAS."""
+        self.logging.update(logging)
+
+    def is_logging(self) -> bool:
+        """Return whether the DAS is logging."""
+        return self.logging.get()
 
     def load_message(self, message: str) -> None:
         """Store a message which is made available by self.get_message."""
@@ -200,7 +212,9 @@ class DataV3(Data):
     def get_topics() -> List[topics.Topic]:
         # TODO: Not have to read configs everytime
         return [
+            topics.WirelessModule.all().start,
             topics.WirelessModule.all().data,
+            topics.WirelessModule.all().stop,
             topics.Camera.overlay_message,
             DataV3.create_voltage_topic(),
             topics.BOOST.recommended_sp,
@@ -220,7 +234,12 @@ class DataV3(Data):
         if topic == topics.Camera.overlay_message:
             self.load_message_json(data)
         elif topics.WirelessModule.all().data.matches(topic):
+            self.set_logging(True)
             self.load_sensor_data(data)
+        elif topics.WirelessModule.all().start.matches(topic):
+            self.set_logging(True)
+        elif topics.WirelessModule.all().stop.matches(topic):
+            self.set_logging(False)
         elif self.create_voltage_topic().matches(topic):
             self.load_voltage_data(data)
         elif topic == topics.BOOST.recommended_sp:

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -7,6 +7,7 @@ from components import (
     DAShboardMessage,
     DASDisconnectMessage,
 )
+from components.logging_indicator import LoggingIndicator
 from overlay import Overlay
 
 
@@ -86,6 +87,9 @@ class OverlayNew(Overlay):
             CentrePower(self.width, self.height),
             DAShboardMessage(),
             DASDisconnectMessage(self.client),
+            LoggingIndicator(
+                (self.width - spacing, top_right_rect[1][1] + spacing)
+            ),
         ]
 
     def _draw_base_layer(self):

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -35,15 +35,9 @@ class OverlayNew(Overlay):
             """Coordinates of the data field in column x, row y."""
             return col_coords[x], row_coords[y]
 
-        # Dimensions of the left TransparentRectangle
-        left_rect = [
+        # Dimensions of the bottom TransparentRectangle
+        bottom_rect = [
             (0, row_coords[0] - DataField.height - spacing),
-            (col_coords[1] + DataField.width + spacing, self.height),
-        ]
-
-        # Dimensions of the right TransparentRectangle
-        right_rect = [
-            (col_coords[2], row_coords[0] - DataField.height - spacing),
             (self.width, self.height),
         ]
 
@@ -54,9 +48,7 @@ class OverlayNew(Overlay):
         ]
         # Create all overlay components
         self.components = [
-            TransparentRectangle(*left_rect),
-            TransparentRectangle(*right_rect),
-            # rectangle for voltage
+            TransparentRectangle(*bottom_rect),
             TransparentRectangle(*top_right_rect),
             DataField(
                 "RPM", self.get_data_func("cadence"), data_field_coord(0, 0)


### PR DESCRIPTION
## Description

- The transparent rectangle in the bottom corners now stretches all the way across. (Note that it is only transparent on the actual displays)
- Added a quick and dirty DAS logging indicator in the top right (the red circle). Disappears when not logging. UI could be improved but I figure anything at all is better than nothing.

I'll probably run this by Charles tomorrow and check there's nothing else he wants.

## Screenshots

![image](https://user-images.githubusercontent.com/17876556/160587347-bf814ec6-74cd-4d62-a80c-6b36e30dc458.png)

## Steps to Test

Using `V3_fake_module.py` from the DAS repo, confirm that the indicator is correct. Note that you can start the camera overlay with `python overlay_new.py`
