### PR TITLE
Add ant+ speed sensor data to overlay

### DIFF
--- a/components/data_field.py
+++ b/components/data_field.py
@@ -79,7 +79,14 @@ class SpeedField(DataField):
         pass
 
     def draw_data(self, canvas: Canvas, data: Data):
-        self.title = "REED KPH" if data["reed_velocity"] else "GPS KPH"
+        if data["ant_speed"]:
+            self.title = "ANT+ KPH"
+        elif data["gps_speed"]:
+            self.title = "GPS KPH"
+        elif data["reed_velocity"]:
+            self.title = "REED KPH"
+        else:
+            self.title = "KPH"
         super().draw_data(canvas, data)
 
 

--- a/components/data_field.py
+++ b/components/data_field.py
@@ -67,8 +67,9 @@ class SpeedField(DataField):
     def __init__(self, coordinate: Tuple[int, int]):
         def value_func(data):
             return (
-                data["reed_velocity"].get_string(decimals=1)
+                data["ant_speed"].get_string(decimals=1)
                 or data["gps_speed"].get_string(decimals=1)
+                or data["reed_velocity"].get_string(decimals=1)
                 or "--"
             )
 

--- a/data.py
+++ b/data.py
@@ -275,13 +275,13 @@ class DataV3(Data):
 
             if sensor_name == "gps":
                 self.data["gps"].update(1)
-                self.data["gps_speed"].update(sensor_value["speed"])
+                self.data["gps_speed"].update(sensor_value["speed"] * 3.6)
             elif sensor_name == "antSpeed":
-                self.data["ant_speed"].update(sensor_value)
+                self.data["ant_speed"].update(sensor_value * 3.6)
             elif sensor_name == "antDistance":
                 self.data["ant_distance"].update(sensor_value)
             elif sensor_name == "reedVelocity":
-                self.data["reed_velocity"].update(sensor_value)
+                self.data["reed_velocity"].update(sensor_value * 3.6)
             elif sensor_name == "reedDistance":
                 self.data["reed_distance"].update(sensor_value)
             elif sensor_name in self.data.keys():

--- a/data.py
+++ b/data.py
@@ -87,6 +87,7 @@ class Data(ABC):
             "heartRate": DataValue(int),
             "gps": DataValue(int),
             "gps_speed": DataValue(float),
+            "ant_speed": DataValue(float),
             "reed_velocity": DataValue(float),
             "reed_distance": DataValue(float),
             # Power model data
@@ -274,6 +275,8 @@ class DataV3(Data):
             if sensor_name == "gps":
                 self.data["gps"].update(1)
                 self.data["gps_speed"].update(sensor_value["speed"])
+            elif sensor_name == "antSpeed":
+                self.data["ant_speed"].update(sensor_value)
             elif sensor_name == "reedVelocity":
                 self.data["reed_velocity"].update(sensor_value)
             elif sensor_name == "reedDistance":

--- a/data.py
+++ b/data.py
@@ -88,6 +88,7 @@ class Data(ABC):
             "gps": DataValue(int),
             "gps_speed": DataValue(float),
             "ant_speed": DataValue(float),
+            "ant_distance": DataValue(float),
             "reed_velocity": DataValue(float),
             "reed_distance": DataValue(float),
             # Power model data
@@ -276,8 +277,9 @@ class DataV3(Data):
                 self.data["gps"].update(1)
                 self.data["gps_speed"].update(sensor_value["speed"])
             elif sensor_name == "antSpeed":
-                self.data["ant_speed"].update(sensor_value["speed"])
-                self.data["ant_distance"].update(sensor_value["distance"])
+                self.data["ant_speed"].update(sensor_value)
+            elif sensor_name == "antDistance":
+                self.data["ant_distance"].update(sensor_value)
             elif sensor_name == "reedVelocity":
                 self.data["reed_velocity"].update(sensor_value)
             elif sensor_name == "reedDistance":

--- a/data.py
+++ b/data.py
@@ -276,7 +276,8 @@ class DataV3(Data):
                 self.data["gps"].update(1)
                 self.data["gps_speed"].update(sensor_value["speed"])
             elif sensor_name == "antSpeed":
-                self.data["ant_speed"].update(sensor_value)
+                self.data["ant_speed"].update(sensor_value["speed"])
+                self.data["ant_distance"].update(sensor_value["distance"])
             elif sensor_name == "reedVelocity":
                 self.data["reed_velocity"].update(sensor_value)
             elif sensor_name == "reedDistance":

--- a/overlay_new.py
+++ b/overlay_new.py
@@ -76,7 +76,7 @@ class OverlayNew(Overlay):
             ),
             DataField(
                 "DIST KM",
-                self.get_data_func("reed_distance", 2, 0.001),
+                self.get_data_func("ant_distance", 2, 0.001),
                 data_field_coord(3, 1),
             ),
             VoltageField(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -192,8 +192,8 @@ class TestDataV3:
         # No fields tracked from front or mid module
         # Test back module
         assert data["gps"].get() == 1
-        assert data["gps_speed"].get() == 20.5
-        assert data["reed_velocity"].get() == 20.1
+        assert data["gps_speed"].get() == 20.5 * 3.6
+        assert data["reed_velocity"].get() == 20.1 * 3.6
         assert data["reed_distance"].get() == 1040.3
         # Test antplus data
         assert data["power"].get() == 249


### PR DESCRIPTION
## Description

Pretty much replaces the reed switch speed/distance. (reed switch data is still available as a fallback without modification)

## Screenshots

<!--- Attach any screenshots relevant to your change --->

## Steps to Test

I've tested on the camera systems. If you want to test, run the overlay locally and publish some data with the sensor name set to "antSpeed" and "antDistance"
