### PR TITLE
Implement V3 start topic for Raspicam

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -109,8 +109,8 @@ class Orchestrator:
 
         # `self.currently_logging` will be updated when we receive the message
         # we publish above.
-        # If start message is sent successfully, as we're subscribed to the topic
-        # `self.logging_state` will be updated in `on_message`
+        # If start message is sent successfully, as we're subscribed to the
+        # topic `self.logging_state` will be updated in `on_message`
         # If the message fails to send, we don't update internal logging state
         # so the next button press causes it to try again
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -108,9 +108,8 @@ class Orchestrator:
         self.set_logging_state(next_logging_state)
         print(f"Set logging state to {next_logging_state}")
 
-        # `self.currently_logging` will be updated when we receive the message we publish above.
-        # if start message is sent successfully, as we're also subscribed to the topic, self.logging_state will be updated in on_message
-        # if it fails to send we don't want to update the internal logging state so that the next button press causes it to try again
+        # `self.currently_logging` will be updated when we receive the message
+        # we publish above.
 
     def set_logging_state(self, logging: bool) -> None:
         """Set the data logging state of the camera, updating the LED."""

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -104,15 +104,17 @@ class Orchestrator:
         # NEW V3 start code
         # If we are currently logging -> false payload
         if self.currently_logging:
-            msg = dumps(
-                {"start": False}
-            )  # JSON formatted string, this is the payload
+            msg = dumps({"start": False})  # JSON formatted string, this is the payload
             self.mqtt_client.publish(topics.V3.start, msg)
+            print('Stopping Logging')
+            self.set_logging_state(False) #Do we need to change the logging state?
 
         # If not -> true payload
         else:
             msg = dumps({"start": True})
             self.mqtt_client.publish(topics.V3.start, msg)
+            print('Starting Logging')
+            self.set_logging_state(True) #Changing the logging state
 
         # OLD BOOST start/stop code
         # self.mqtt_client.publish(
@@ -235,4 +237,3 @@ if __name__ == "__main__":
     finally:
         if ON_PI:
             cleanup()
-            

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -101,32 +101,26 @@ class Orchestrator:
             topic = module.stop if self.currently_logging else module.start
             self.mqtt_client.publish(str(topic))
 
-        # NEW V3 start code
+        # Publish to V3 start topic if button on display is pressed
         # If we are currently logging -> false payload
         if self.currently_logging:
-            msg = dumps({"start": False})  # JSON formatted string, this is the payload
-            self.mqtt_client.publish(topics.V3.start, msg)
-            print('Stopping Logging')
-            self.set_logging_state(False) #Do we need to change the logging state?
+            msg = dumps(
+                {"start": False}
+            )  # JSON formatted string, this is the payload
+            self.mqtt_client.publish(topics.V3.start, msg)  # Publish
+            self.set_logging_state(False)  # Changing the logging state
+            print(
+                "Stopping Logging"
+            )  # Check that at least if statement is executing
 
         # If not -> true payload
         else:
             msg = dumps({"start": True})
-            self.mqtt_client.publish(topics.V3.start, msg)
-            print('Starting Logging')
-            self.set_logging_state(True) #Changing the logging state
-
-        # OLD BOOST start/stop code
-        # self.mqtt_client.publish(
-        #     str(
-        #         topics.BOOST.stop
-        #         if self.currently_logging
-        #         else topics.BOOST.start
-        #     )
-        # )
-
-        # `self.currently_logging` will be updated when we receive the message
-        # we publish above.
+            self.mqtt_client.publish(topics.V3.start, msg)  # Publish
+            self.set_logging_state(True)  # Changing the logging state
+            print(
+                "Starting Logging"
+            )  # Check that at least if statement is executing
 
     def set_logging_state(self, logging: bool) -> None:
         """Set the data logging state of the camera, updating the LED."""
@@ -139,12 +133,16 @@ class Orchestrator:
 
     def publish_camera_status(self) -> None:
         """Send a message on the current device's camera status topic."""
-        status_topic = topics.Camera.status_camera + "/" + self.device #Quick fix to operator overload not working on rpi
+        status_topic = (
+            topics.Camera.status_camera + "/" + self.device
+        )  # Quick fix to operator overload not working on rpi
         message = dumps({"connected": True, "ipAddress": get_ip()})
         self.mqtt_client.publish(status_topic, message, retain=True)
 
     def battery_loop(self) -> None:
-        status_topic = topics.Camera.status_camera + "/" + self.device + "/" + "battery" #Quick fix to operator overload not working on rpi
+        status_topic = (
+            topics.Camera.status_camera + "/" + self.device + "/" + "battery"
+        )  # Quick fix to operator overload not working on rpi
         message = dumps({"voltage": self.get_battery_voltage()})
         self.mqtt_client.publish(str(status_topic), message, retain=True)
 
@@ -159,7 +157,9 @@ class Orchestrator:
         client.subscribe(str(topics.Camera.set_overlay))
         client.subscribe(str(topics.Camera.get_overlays))
         client.subscribe(str(topics.WirelessModule.all().module))
-        client.subscribe(topics.Camera.flip_video_feed + "/" + self.device) #operator overload wasn't working on rpi, quick fix
+        client.subscribe(
+            topics.Camera.flip_video_feed + "/" + self.device
+        )  # operator overload wasn't working on rpi, quick fix
         self.publish_camera_status()
         if ON_PI:
             self.connected_led.turn_on()
@@ -187,7 +187,9 @@ class Orchestrator:
                 self.set_logging_state(True)
         elif topics.WirelessModule.all().stop.matches(msg.topic):
             self.set_logging_state(False)
-        elif msg.topic == topics.Camera.flip_video_feed + "/" + self.device: #Quick fix to operator overload not working on rpi
+        elif (
+            msg.topic == topics.Camera.flip_video_feed + "/" + self.device
+        ):  # Quick fix to operator overload not working on rpi
             rotation = config.read_configs().get(config.ROTATION_KEY, 0) + 180
             config.set_rotation(rotation % 360)
 
@@ -211,7 +213,9 @@ class Orchestrator:
         self.mqtt_client.connect_async(self.broker_ip, self.port, 60)
 
         # Set the camera status to offline if connection breaks
-        camera_topic = topics.Camera.status_camera + "/" + self.device #Quick fix to operator overload not working on rpi
+        camera_topic = (
+            topics.Camera.status_camera + "/" + self.device
+        )  # Quick fix to operator overload not working on rpi
         self.mqtt_client.will_set(
             camera_topic, dumps({"connected": False}), 1, True
         )

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -102,25 +102,15 @@ class Orchestrator:
             self.mqtt_client.publish(str(topic))
 
         # Publish to V3 start topic if button on display is pressed
-        # If we are currently logging -> false payload
-        if self.currently_logging:
-            msg = dumps(
-                {"start": False}
-            )  # JSON formatted string, this is the payload
-            self.mqtt_client.publish(topics.V3.start, msg)  # Publish
-            self.set_logging_state(False)  # Changing the logging state
-            print(
-                "Stopping Logging"
-            )  # Check that at least if statement is executing
+        next_logging_state = not self.currently_logging
+        msg = dumps({"start": next_logging_state})
+        self.mqtt_client.publish(topics.V3.start, msg)
+        self.set_logging_state(next_logging_state)
+        print(f"Set logging state to {next_logging_state}")
 
-        # If not -> true payload
-        else:
-            msg = dumps({"start": True})
-            self.mqtt_client.publish(topics.V3.start, msg)  # Publish
-            self.set_logging_state(True)  # Changing the logging state
-            print(
-                "Starting Logging"
-            )  # Check that at least if statement is executing
+        # `self.currently_logging` will be updated when we receive the message we publish above.
+        # if start message is sent successfully, as we're also subscribed to the topic, self.logging_state will be updated in on_message
+        # if it fails to send we don't want to update the internal logging state so that the next button press causes it to try again
 
     def set_logging_state(self, logging: bool) -> None:
         """Set the data logging state of the camera, updating the LED."""

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -105,11 +105,14 @@ class Orchestrator:
         next_logging_state = not self.currently_logging
         msg = dumps({"start": next_logging_state})
         self.mqtt_client.publish(topics.V3.start, msg)
-        self.set_logging_state(next_logging_state)
         print(f"Set logging state to {next_logging_state}")
 
         # `self.currently_logging` will be updated when we receive the message
         # we publish above.
+        # If start message is sent successfully, as we're subscribed to the topic
+        # `self.logging_state` will be updated in `on_message`
+        # If the message fails to send, we don't update internal logging state
+        # so the next button press causes it to try again
 
     def set_logging_state(self, logging: bool) -> None:
         """Set the data logging state of the camera, updating the LED."""

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -101,18 +101,20 @@ class Orchestrator:
             topic = module.stop if self.currently_logging else module.start
             self.mqtt_client.publish(str(topic))
 
-        #NEW V3 start code
-        #If we are currently logging -> false payload
+        # NEW V3 start code
+        # If we are currently logging -> false payload
         if self.currently_logging:
-            msg = dumps({"start": False}) #JSON formatted string, this is the payload
+            msg = dumps(
+                {"start": False}
+            )  # JSON formatted string, this is the payload
             self.mqtt_client.publish(topics.V3.start, msg)
 
-        #If not -> true payload
+        # If not -> true payload
         else:
             msg = dumps({"start": True})
             self.mqtt_client.publish(topics.V3.start, msg)
 
-        #OLD BOOST start/stop code
+        # OLD BOOST start/stop code
         # self.mqtt_client.publish(
         #     str(
         #         topics.BOOST.stop

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -101,13 +101,25 @@ class Orchestrator:
             topic = module.stop if self.currently_logging else module.start
             self.mqtt_client.publish(str(topic))
 
-        self.mqtt_client.publish(
-            str(
-                topics.BOOST.stop
-                if self.currently_logging
-                else topics.BOOST.start
-            )
-        )
+        #NEW V3 start code
+        #If we are currently logging -> false payload
+        if self.currently_logging:
+            msg = dumps({"start": False}) #JSON formatted string, this is the payload
+            self.mqtt_client.publish(topics.V3.start, msg)
+
+        #If not -> true payload
+        else:
+            msg = dumps({"start": True})
+            self.mqtt_client.publish(topics.V3.start, msg)
+
+        #OLD BOOST start/stop code
+        # self.mqtt_client.publish(
+        #     str(
+        #         topics.BOOST.stop
+        #         if self.currently_logging
+        #         else topics.BOOST.start
+        #     )
+        # )
 
         # `self.currently_logging` will be updated when we receive the message
         # we publish above.

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -125,16 +125,12 @@ class Orchestrator:
 
     def publish_camera_status(self) -> None:
         """Send a message on the current device's camera status topic."""
-        status_topic = (
-            topics.Camera.status_camera + "/" + self.device
-        )  # Quick fix to operator overload not working on rpi
+        status_topic = str(topics.Camera.status_camera / self.device)
         message = dumps({"connected": True, "ipAddress": get_ip()})
         self.mqtt_client.publish(status_topic, message, retain=True)
 
     def battery_loop(self) -> None:
-        status_topic = (
-            topics.Camera.status_camera + "/" + self.device + "/" + "battery"
-        )  # Quick fix to operator overload not working on rpi
+        status_topic = topics.Camera.status_camera / self.device / "battery"
         message = dumps({"voltage": self.get_battery_voltage()})
         self.mqtt_client.publish(str(status_topic), message, retain=True)
 
@@ -149,9 +145,7 @@ class Orchestrator:
         client.subscribe(str(topics.Camera.set_overlay))
         client.subscribe(str(topics.Camera.get_overlays))
         client.subscribe(str(topics.WirelessModule.all().module))
-        client.subscribe(
-            topics.Camera.flip_video_feed + "/" + self.device
-        )  # operator overload wasn't working on rpi, quick fix
+        client.subscribe(str(topics.Camera.flip_video_feed / self.device))
         self.publish_camera_status()
         if ON_PI:
             self.connected_led.turn_on()
@@ -179,9 +173,7 @@ class Orchestrator:
                 self.set_logging_state(True)
         elif topics.WirelessModule.all().stop.matches(msg.topic):
             self.set_logging_state(False)
-        elif (
-            msg.topic == topics.Camera.flip_video_feed + "/" + self.device
-        ):  # Quick fix to operator overload not working on rpi
+        elif msg.topic == topics.Camera.flip_video_feed / self.device:
             rotation = config.read_configs().get(config.ROTATION_KEY, 0) + 180
             config.set_rotation(rotation % 360)
 
@@ -205,9 +197,7 @@ class Orchestrator:
         self.mqtt_client.connect_async(self.broker_ip, self.port, 60)
 
         # Set the camera status to offline if connection breaks
-        camera_topic = (
-            topics.Camera.status_camera + "/" + self.device
-        )  # Quick fix to operator overload not working on rpi
+        camera_topic = str(topics.Camera.status_camera / self.device)
         self.mqtt_client.will_set(
             camera_topic, dumps({"connected": False}), 1, True
         )

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -137,12 +137,12 @@ class Orchestrator:
 
     def publish_camera_status(self) -> None:
         """Send a message on the current device's camera status topic."""
-        status_topic = str(topics.Camera.status_camera / self.device)
+        status_topic = topics.Camera.status_camera + "/" + self.device #Quick fix to operator overload not working on rpi
         message = dumps({"connected": True, "ipAddress": get_ip()})
         self.mqtt_client.publish(status_topic, message, retain=True)
 
     def battery_loop(self) -> None:
-        status_topic = topics.Camera.status_camera / self.device / "battery"
+        status_topic = topics.Camera.status_camera + "/" + self.device + "/" + "battery" #Quick fix to operator overload not working on rpi
         message = dumps({"voltage": self.get_battery_voltage()})
         self.mqtt_client.publish(str(status_topic), message, retain=True)
 
@@ -157,7 +157,7 @@ class Orchestrator:
         client.subscribe(str(topics.Camera.set_overlay))
         client.subscribe(str(topics.Camera.get_overlays))
         client.subscribe(str(topics.WirelessModule.all().module))
-        client.subscribe(str(topics.Camera.flip_video_feed / self.device))
+        client.subscribe(topics.Camera.flip_video_feed + "/" + self.device) #operator overload wasn't working on rpi, quick fix
         self.publish_camera_status()
         if ON_PI:
             self.connected_led.turn_on()
@@ -185,7 +185,7 @@ class Orchestrator:
                 self.set_logging_state(True)
         elif topics.WirelessModule.all().stop.matches(msg.topic):
             self.set_logging_state(False)
-        elif msg.topic == topics.Camera.flip_video_feed / self.device:
+        elif msg.topic == topics.Camera.flip_video_feed + "/" + self.device: #Quick fix to operator overload not working on rpi
             rotation = config.read_configs().get(config.ROTATION_KEY, 0) + 180
             config.set_rotation(rotation % 360)
 
@@ -209,7 +209,7 @@ class Orchestrator:
         self.mqtt_client.connect_async(self.broker_ip, self.port, 60)
 
         # Set the camera status to offline if connection breaks
-        camera_topic = str(topics.Camera.status_camera / self.device)
+        camera_topic = topics.Camera.status_camera + "/" + self.device #Quick fix to operator overload not working on rpi
         self.mqtt_client.will_set(
             camera_topic, dumps({"connected": False}), 1, True
         )
@@ -235,3 +235,4 @@ if __name__ == "__main__":
     finally:
         if ON_PI:
             cleanup()
+            

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python-dotenv = "^0.13.0"
 picamera = { version = "^1.13", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 "RPi.GPIO" = { version = "^0.7.0", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 adafruit-circuitpython-mcp3xxx = { version = "^1.4.5", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
-mhp = { git = "git@github.com:monash-human-power/common.git", rev = "202212.21" }
+mhp = { git = "git@github.com:monash-human-power/common.git", rev = "20220.20" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python-dotenv = "^0.13.0"
 picamera = { version = "^1.13", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 "RPi.GPIO" = { version = "^0.7.0", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 adafruit-circuitpython-mcp3xxx = { version = "^1.4.5", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
-mhp = { git = "git@github.com:monash-human-power/common.git", rev = "202207.19" }
+mhp = { git = "git@github.com:monash-human-power/common.git", rev = "202212.21" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python-dotenv = "^0.13.0"
 picamera = { version = "^1.13", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 "RPi.GPIO" = { version = "^0.7.0", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 adafruit-circuitpython-mcp3xxx = { version = "^1.4.5", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
-mhp = { git = "git@github.com:monash-human-power/common.git", rev = "202203.15" }
+mhp = { git = "git@github.com:monash-human-power/common.git", rev = "20220.19" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python-dotenv = "^0.13.0"
 picamera = { version = "^1.13", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 "RPi.GPIO" = { version = "^0.7.0", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 adafruit-circuitpython-mcp3xxx = { version = "^1.4.5", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
-mhp = { git = "git@github.com:monash-human-power/common.git", rev = "202208.20" }
+mhp = { git = "git@github.com:monash-human-power/common.git", rev = "202212.21" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python-dotenv = "^0.13.0"
 picamera = { version = "^1.13", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 "RPi.GPIO" = { version = "^0.7.0", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 adafruit-circuitpython-mcp3xxx = { version = "^1.4.5", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
-mhp = { git = "git@github.com:monash-human-power/common.git", rev = "20220.19" }
+mhp = { git = "git@github.com:monash-human-power/common.git", rev = "202207.19" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.2"


### PR DESCRIPTION
## Description

<!--- What does your pull request change? What changes are expected? --->
The changes to raspicam simply publish the new V3 start topic whenever the logging button on the displays are pressed. This signals for BOOST and WM to start logging.

## Screenshots

<!--- Attach any screenshots relevant to your change --->
![image](https://user-images.githubusercontent.com/97724307/180416934-57c77fcd-a116-4bed-b65c-c82131cd6001.png)

## Steps to Test

<!--- How does someone check your change? --->
The physical display is required for testing and can be found in Makerspace.
1. Set up a hotspot, the name of the hotspot should be **MHP_MobileNet** and the password should be the usual.
2. Connect your device and the display to the hotspot network. 
3. Form an SSH connection through any means.
4. Open the raspicam file that is on the display, pull the changes using `git pull`.
5. On the `orchestrator.py` file comment out the body of the `on_message` method and replace with `pass`, as shown above.
6. Ensure your mosquitto broker is active, then in a terminal run the command `mosquitto_sub -t 'v3/start'`.
7. Open a `poetry shell`.
8. Run the command `python orchestrator.py --host [YOUR IP]`, replacing `[YOUR IP]` with the IP address of the device you're using.
9. Once the script is running:
a. Press the logging button, the subscription terminal should read `{"start": True}` if successful.
b. Press the logging button again, the subscription terminal should read `{"start": False}` if successful.
c. Take note of the LEDs on the physical display, the red LED should turn on and off.