### PR TITLE
Log Issue Bug Fix

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -162,6 +162,8 @@ class Orchestrator:
         self.mqtt_client.on_disconnect = self.on_disconnect
         self.mqtt_client.connect_async(self.broker_ip, self.port, 60)
 
+        print("this is start topic: {topics.V3.start}")
+
         # Set the camera status to offline if connection breaks
         camera_topic = str(topics.Camera.status_camera / self.device)
         self.mqtt_client.will_set(

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -72,7 +72,10 @@ class Orchestrator:
         # Publish to V3 start topic if button on display is pressed
         next_logging_state = not self.currently_logging
         msg = dumps({"start": next_logging_state})
-        self.mqtt_client.publish(topics.V3.start, msg)
+
+        print(f"\n\nTopic: {str(topics.V3.start)} \nMessage: {msg}")
+
+        self.mqtt_client.publish(str(topics.V3.start), msg)
         print(f"Set logging state to {next_logging_state}")
 
         # `self.currently_logging` will be updated when we receive the message
@@ -161,8 +164,6 @@ class Orchestrator:
         self.mqtt_client.on_log = self.on_log
         self.mqtt_client.on_disconnect = self.on_disconnect
         self.mqtt_client.connect_async(self.broker_ip, self.port, 60)
-
-        print(f"this is start topic: {topics.V3.start}")
 
         # Set the camera status to offline if connection breaks
         camera_topic = str(topics.Camera.status_camera / self.device)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -72,9 +72,6 @@ class Orchestrator:
         # Publish to V3 start topic if button on display is pressed
         next_logging_state = not self.currently_logging
         msg = dumps({"start": next_logging_state})
-
-        print(f"\n\nTopic: {str(topics.V3.start)} \nMessage: {msg}")
-
         self.mqtt_client.publish(str(topics.V3.start), msg)
         print(f"Set logging state to {next_logging_state}")
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -162,7 +162,7 @@ class Orchestrator:
         self.mqtt_client.on_disconnect = self.on_disconnect
         self.mqtt_client.connect_async(self.broker_ip, self.port, 60)
 
-        print("this is start topic: {topics.V3.start}")
+        print(f"this is start topic: {topics.V3.start}")
 
         # Set the camera status to offline if connection breaks
         camera_topic = str(topics.Camera.status_camera / self.device)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python-dotenv = "^0.13.0"
 picamera = { version = "^1.13", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 "RPi.GPIO" = { version = "^0.7.0", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
 adafruit-circuitpython-mcp3xxx = { version = "^1.4.5", markers = "platform_machine == 'armv6l' or platform_machine == 'armv7l'" }
-mhp = { git = "git@github.com:monash-human-power/common.git", rev = "20220.20" }
+mhp = { git = "git@github.com:monash-human-power/common.git", rev = "202212.21" }
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.2"


### PR DESCRIPTION
## Description
This one-line change should fix the issue of the V3 systems not starting or logging data. 

## Screenshots

<!--- Attach any screenshots relevant to your change --->

## Steps to Test

1. Set up a hotspot with name `MHPMobile_Net` and the normal password.
2. SSH into both displays and switch to this branch of raspicam, then restart the displays.
3. Ensure the displays are connected with HDMI and radio cables.
4. On the primary display run the command, `systemctl --user restart ant-plus.service`.
5. Open a terminal and run the command `mosquitto_sub -t "#" -h "mhp-v3-primary.local`.
7. Press the log button once and check that data is being published (it can be empty data if the back wireless module isn't set up).
8. Press the log button again, and check that data isn't being published anymore.
9. Also spin the pedals and check that data is on the displays.
